### PR TITLE
implemented listener and socket classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+BIN_DIR = bin
+BUILD_DIRS = sadmd sadcd sadfsd comm example $(BIN_DIR)
 BUILD = build
-BUILD_DIRS = sadmd sadcd sadfsd
+BIN = $(BUILD)/$(BIN_DIR)
 SRC = src
 INC = include
 LIB = boost_program_options
@@ -17,23 +19,26 @@ else
 	CXX = g++
 endif
 
+CXX_FLAGS = -c -std=c++17 -ggdb
 # do not optimize if requested
 ifneq "$(OPT)" "no"
 	CXX_FLAGS += -O
 endif
-
-CXX_FLAGS = -c -std=c++17 -ggdb
 CXX_INC = $(INC:%=-I%)       # add '-I' prefix to each value in INC
 CXX_LIB = $(LIB:%=-l%)       # add '-l' prefix to each value in LIB
 CXX_LIB += $(LIB_DIRS:%=-L%) # add '-L' prefix to each value in LIB_DIRS
 
 # build source file list
+COMMON_SRC = $(wildcard $(SRC)/comm/*.cpp)
+
 SADMD_SRC = $(filter-out \
 	    $(SRC)/sadmd/sadmd-bootstrap.cpp, \
 	    $(wildcard $(SRC)/sadmd/*.cpp))
+
 SADCD_SRC = $(filter-out \
 	    $(SRC)/sadcd/sadcd-bootstrap.cpp, \
 	    $(wildcard $(SRC)/sadcd/*.cpp))
+
 SADFSD_SRC = $(filter-out \
 	     $(SRC)/sadfsd/sadfsd-bootstrap.cpp, \
 	     $(wildcard $(SRC)/sadfsd/*.cpp))
@@ -42,29 +47,40 @@ SADFSD_SRC = $(filter-out \
 SADMD_OBJ = $(SADMD_SRC:$(SRC)/%.cpp=$(BUILD)/%.o)
 SADCD_OBJ = $(SADCD_SRC:$(SRC)/%.cpp=$(BUILD)/%.o)
 SADFSD_OBJ = $(SADFSD_SRC:$(SRC)/%.cpp=$(BUILD)/%.o)
+COMMON_OBJ = $(COMMON_SRC:$(SRC)/%.cpp=$(BUILD)/%.o)
 
-client: sadfsd-bootstrap
+client: $(BIN)/sadfsd-bootstrap
 
-master: sadmd-bootstrap 
+master: $(BIN)/sadmd-bootstrap
 
-chunk: sadcd-bootstrap
+chunk: $(BIN)/sadcd-bootstrap
 
-sadfsd-bootstrap: mkdirs $(BUILD)/sadfsd/sadfsd-bootstrap.o
-	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $(BUILD)/$@
+ex: $(patsubst example/%.cpp, $(BIN)/%, $(wildcard example/*.cpp))
 
-sadmd-bootstrap: mkdirs $(BUILD)/sadmd/sadmd-bootstrap.o
-	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $(BUILD)/$@
+# sadfs binaries
+$(BIN)/%: mkdirs $(BUILD)/sadfsd/%.o
+	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $@
 
-sadcd-bootstrap: mkdirs $(BUILD)/sadcd/sadcd-bootstrap.o
-	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $(BUILD)/$@
+$(BIN)/%: mkdirs $(BUILD)/sadmd/%.o
+	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $@
+
+$(BIN)/%: mkdirs $(BUILD)/sadcd/%.o
+	$(CXX) $(filter-out $<, $^) $(CXX_LIB) -o $@
 
 $(BUILD)/%.o: $(SRC)/%.cpp
-	$(CXX) $(CXX_FLAGS) $(CXX_INC) $^ -o $@
+	$(CXX) $(CXX_FLAGS) $(CXX_INC) $< -o $@
+
+# example binaries
+$(BIN)/%: mkdirs $(BUILD)/example/%.o $(COMMON_OBJ)
+	$(CXX) $(filter-out $<, $^) -o $@
+
+$(BUILD)/example/%.o: example/%.cpp
+	$(CXX) $(CXX_FLAGS) $(CXX_INC) $< -o $@
 
 clean:
 	@-rm -r $(BUILD) >/dev/null 2>&1
 
 mkdirs:
-	@-mkdir -p $(BUILD_DIRS:%=$(BUILD)/%)
+	@mkdir -p $(BUILD_DIRS:%=$(BUILD)/%)
 
-.PHONY: clean mkdirs all sadmd-bootstrap sadcd-bootstrap sadfsd-bootstrap
+.PHONY: clean mkdirs client master chunk ex

--- a/example/echod.cpp
+++ b/example/echod.cpp
@@ -1,0 +1,38 @@
+/* example code for testing sadfs::inet::listener */
+#include <sadfs/comm/inet.hpp>
+
+#include <array>
+#include <iostream>
+#include <unistd.h>
+
+int
+main()
+{
+	using namespace sadfs;
+	auto listener = inet::listener{inet::constants::ip_localhost, 6666};
+	auto buf = std::array<char, 512>{};
+	auto len = 0;
+
+	while (true)
+	{
+		auto sock = listener.accept();
+		std::cout << "accepted: " << sock.descriptor() << "\n";
+
+		while ((len = ::read(sock.descriptor(), buf.data(), buf.size())))
+		{
+			if (len == -1)
+			{
+				std::cerr << "read error\n";
+				std::exit(1);
+			}
+			if (::write(sock.descriptor(), buf.data(), len) == -1)
+			{
+				std::cerr << "write error\n";
+				std::exit(1);
+			}
+
+			std::cout << buf.data() << "\n";
+			buf.fill({});
+		}
+	}
+}

--- a/example/msg.cpp
+++ b/example/msg.cpp
@@ -1,0 +1,45 @@
+#include <sadfs/comm/inet.hpp>
+
+#include <arpa/inet.h>
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int
+main(int argc, char** argv)
+{
+	using namespace sadfs;
+
+	auto sock = sadfs::socket(socket::domain::inet, socket::type::stream);
+	auto addr = sockaddr_in
+	{
+		.sin_family = AF_INET,
+		.sin_port = htons(6666),
+		.sin_addr = {inet::ip_addr("127.0.0.1").value()}
+	};
+	if (connect(sock.descriptor(),
+	            reinterpret_cast<sockaddr const*>(&addr),
+	            sizeof(addr)) == -1)
+	{
+		return -1;
+	}
+
+	char const* msg{(argc > 1) ? argv[1] : "hi, there"};
+	if (send(sock.descriptor(), msg, strlen(msg), 0) == -1)
+	{
+		return -2;
+	}
+
+	auto buf = std::array<char, 128>{};
+	if (recv(sock.descriptor(), buf.data(), buf.size(), 0) == -1)
+	{
+		return -3;
+	}
+	std::cout << buf.data() << '\n';
+
+	return 0;
+}

--- a/example/msg.cpp
+++ b/example/msg.cpp
@@ -15,12 +15,10 @@ main(int argc, char** argv)
 	using namespace sadfs;
 
 	auto sock = sadfs::socket(socket::domain::inet, socket::type::stream);
-	auto addr = sockaddr_in
-	{
-		.sin_family = AF_INET,
-		.sin_port = htons(6666),
-		.sin_addr = {inet::ip_addr("127.0.0.1").value()}
-	};
+	auto addr = sockaddr_in{};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(6666);
+	addr.sin_addr = {inet::constants::ip_localhost.value()};
 	if (connect(sock.descriptor(),
 	            reinterpret_cast<sockaddr const*>(&addr),
 	            sizeof(addr)) == -1)

--- a/include/sadfs/comm/defaults.hpp
+++ b/include/sadfs/comm/defaults.hpp
@@ -1,0 +1,13 @@
+/* communications-related defaults */
+
+namespace sadfs { namespace defaults {
+
+#ifdef __OpenBSD__
+// max size of the queue of pending socket connections
+inline constexpr int somaxconn{128};
+#else // __linux__
+inline constexpr int somaxconn{4096};
+#endif
+
+} // defaults
+} // sadfs

--- a/include/sadfs/comm/inet.hpp
+++ b/include/sadfs/comm/inet.hpp
@@ -1,0 +1,58 @@
+#ifndef SADFS_COMM_INET_HPP
+#define SADFS_COMM_INET_HPP
+
+// sadfs-specific includes
+#include <sadfs/comm/socket.hpp>
+
+// standard includes
+#include <cstdint>
+
+namespace sadfs { namespace inet {
+
+using port_no = std::uint16_t;
+
+// encodes a dotted-decimal ip address as a
+// 32-bit unsigned integer in network byte order
+// see: inet_aton(3)
+class ip_addr
+{
+public:
+	// ip should be a string literal representing
+	// an address in dotted-decimal fashion
+	// ex: "127.0.0.1"
+	ip_addr(char const* ip);
+	std::uint32_t value() const noexcept;
+private:
+	std::uint32_t addr_;
+};
+
+// abstracts listening on a port number for
+// incoming connections
+class listener
+{
+public:
+	// creates a listener on socket specified by
+	// ip_addr and port_no
+	listener(ip_addr const&, port_no);
+
+	listener(listener const&) = delete;
+	listener(listener&&) = default;
+	~listener() = default;
+
+	// accepts a new connection and returns a socket
+	socket accept() const;
+private:
+	ip_addr ip_;
+	port_no port_;
+	socket  socket_;
+};
+
+namespace constants { // sadfs::inet::constants
+
+inline ip_addr const ip_localhost("127.0.0.1");
+
+} // constants namespace
+} // inet
+} // sadfs
+
+#endif // SADFS_COMM_INET_HPP

--- a/include/sadfs/comm/socket.hpp
+++ b/include/sadfs/comm/socket.hpp
@@ -1,0 +1,36 @@
+#ifndef SADFS_SOCKET_HPP
+#define SADFS_SOCKET_HPP
+
+namespace sadfs {
+
+class socket
+{
+public:
+	enum class domain { local, inet };
+	enum class type { stream, datagram };
+
+	// creates a new socket
+	socket(domain const, type const);
+
+	// creates a representation of an existing socket
+	// does not create a new socket
+	socket(domain const, type const, int const) noexcept;
+
+	socket(socket&&) noexcept;
+	socket(socket const&) = delete;
+	~socket() noexcept;
+
+	// accessors
+	domain comm_domain() const noexcept;
+	type   socket_type() const noexcept;
+	int    descriptor()  const noexcept;
+
+private:
+	domain domain_;
+	type   type_;
+	int    descriptor_;
+};
+
+} // sadfs
+
+#endif // SADFS_SOCKET_HPP

--- a/include/sadfs/sadmd/defaults.hpp
+++ b/include/sadfs/sadmd/defaults.hpp
@@ -5,13 +5,13 @@
 
 namespace sadfs { namespace sadmd { namespace defaults {
 
-	// default configuration file path.
-	// since boost::program_options expects a const& to a
-	// std::string while setting an option's default value,
-	// this cannot be a std::string_view. if we were to use a
-	// std::string_view, we would have to construct a std::string
-	// at runtime, which isn't appropriate for this use-case
-	std::string const config_path("/etc/sadmd.conf");
+// default configuration file path.
+// since boost::program_options expects a const& to a
+// std::string while setting an option's default value,
+// this cannot be a std::string_view. if we were to use a
+// std::string_view, we would have to construct a std::string
+// at runtime, which isn't appropriate for this use-case
+inline std::string const config_path("/etc/sadmd.conf");
 
 } // defaults
 } // sadmd

--- a/src/comm/inet.cpp
+++ b/src/comm/inet.cpp
@@ -52,14 +52,10 @@ listener(ip_addr const& ip, port_no port)
 	  socket_(socket::domain::inet, socket::type::stream)
 {
 	// bind to ip + port
-	auto addr = sockaddr_in
-	{
-		.sin_len    = 0,
-		.sin_family = AF_INET,
-		.sin_port   = htons(port_),
-		.sin_addr   {ip_.value()},
-		.sin_zero   {}
-	};
+	auto addr = sockaddr_in{};
+	addr.sin_family = AF_INET;
+	addr.sin_port   = htons(port_);
+	addr.sin_addr   = {ip_.value()};
 	if (::bind(socket_.descriptor(),
 	           reinterpret_cast<sockaddr const*>(&addr),
 	           sizeof(addr)) == -1)

--- a/src/comm/inet.cpp
+++ b/src/comm/inet.cpp
@@ -1,0 +1,97 @@
+/* implementation of inet communication components */
+
+// sadfs-specific includes
+#include <sadfs/comm/inet.hpp>
+#include <sadfs/comm/defaults.hpp>
+
+// standard includes
+#include <arpa/inet.h>  // inet_aton, inet_ntoa, htons, ntohs
+#include <cerrno>       // errno
+#include <netinet/in.h> // in_addr
+#include <sstream>      // std::stringstream
+#include <system_error> // std::system_error, std::system_category
+#include <sys/socket.h> // bind, listen, accept
+
+namespace sadfs { namespace inet {
+
+ip_addr::
+ip_addr(char const* ip)
+{
+	auto tmp = in_addr{};
+	if (inet_aton(ip, &tmp) == 0)
+	{
+		auto err = std::stringstream{};
+		err << ip << " is malformed";
+		throw std::invalid_argument(err.str());
+	}
+	addr_ = tmp.s_addr;
+}
+
+std::uint32_t ip_addr::
+value() const noexcept
+{
+	return addr_;
+}
+
+namespace {
+
+// lambda that formats error messages
+auto fmt_err = [](char const* msg, ip_addr const& ip, port_no const port)
+{
+	auto err = std::stringstream{};
+	err << msg << inet_ntoa({ip.value()})
+	    << ":" << ntohs(port);
+	return err.str();
+};
+
+} // unnamed namespace
+
+listener::
+listener(ip_addr const& ip, port_no port)
+	: ip_(ip), port_(port),
+	  socket_(socket::domain::inet, socket::type::stream)
+{
+	// bind to ip + port
+	auto addr = sockaddr_in
+	{
+		.sin_len    = 0,
+		.sin_family = AF_INET,
+		.sin_port   = htons(port_),
+		.sin_addr   {ip_.value()},
+		.sin_zero   {}
+	};
+	if (::bind(socket_.descriptor(),
+	           reinterpret_cast<sockaddr const*>(&addr),
+	           sizeof(addr)) == -1)
+	{
+		throw std::system_error(errno, std::system_category(),
+		          fmt_err("failed to bind socket to: ", ip_, port_));
+	}
+
+	// specify that connections will be accepted on socket
+	if (::listen(socket_.descriptor(), ::sadfs::defaults::somaxconn) == -1)
+	{
+		throw std::system_error(errno, std::system_category(),
+		          fmt_err("failed to listen on: ", ip_, port_));
+	}
+}
+
+socket listener::
+accept() const
+{
+	auto addr = sockaddr{};
+	auto len = socklen_t{sizeof(addr)};
+	auto desc = ::accept(socket_.descriptor(),
+	                     reinterpret_cast<sockaddr*>(&addr),
+	                     &len);
+	if (desc == -1)
+	{
+		throw std::system_error(errno, std::system_category(),
+		          fmt_err("failed to accept a connection on: ", ip_, port_));
+	}
+
+	return {socket_.comm_domain(), socket_.socket_type(), desc};
+}
+
+} // namespace inet
+} // namespace sadfs

--- a/src/comm/socket.cpp
+++ b/src/comm/socket.cpp
@@ -1,0 +1,101 @@
+/* implementation of sadfs::socket */
+
+// sadfs-specific includes
+#include <sadfs/comm/socket.hpp>
+
+// standard includes
+#include <stdexcept>    // std::invalid_argument
+#include <system_error> // std::system_error, std::system_category
+#include <sys/socket.h> // ::socket
+#include <unistd.h>     // ::close
+
+namespace sadfs {
+namespace {
+
+int
+lookup(socket::domain const domain)
+{
+	switch (domain)
+	{
+		case socket::domain::local:
+			return AF_UNIX;
+		case socket::domain::inet:
+			return AF_INET;
+	}
+	throw std::invalid_argument("unsupported domain");
+}
+
+int
+lookup(socket::type const type)
+{
+	switch (type)
+	{
+		case socket::type::stream:
+			return SOCK_STREAM;
+		case socket::type::datagram:
+			return SOCK_DGRAM;
+	}
+	throw std::invalid_argument("unsupported socket type");
+}
+
+} // unnamed namespace
+
+socket::
+socket(domain const domain, type const type)
+{
+	// let the OS choose protocol by passing 0
+	descriptor_ = ::socket(lookup(domain), lookup(type), /* protocol */ 0);
+	if (descriptor_ == -1)
+	{
+		throw std::system_error(errno, std::system_category(),
+		                        "socket creation failed");
+	}
+
+	domain_ = domain;
+	type_ = type;
+}
+
+socket::
+socket(domain const domain, type const type, int const descriptor) noexcept
+	: domain_(domain), type_(type), descriptor_(descriptor)
+{
+	// TODO: verify parameters
+}
+
+socket::
+socket(socket&& other) noexcept
+	: domain_(other.domain_), type_(other.type_),
+	  descriptor_(other.descriptor_)
+{
+	// prevent other's destructor from closing the descriptor
+	other.descriptor_ = -1;
+}
+
+socket::
+~socket() noexcept
+{
+	if (descriptor_ != -1)
+	{
+		::close(descriptor_);
+	}
+}
+
+socket::domain socket::
+comm_domain() const noexcept
+{
+	return domain_;
+}
+
+socket::type socket::
+socket_type() const noexcept
+{
+	return type_;
+}
+
+int socket::
+descriptor() const noexcept
+{
+	return descriptor_;
+}
+
+} // sadfs


### PR DESCRIPTION
**NOTE:** To be squashed and merged instead of plain merge

* can create a listener class by specifying ip and port number
* can accept connections
* ~yet to implement exception throwing when a class-invariant cannot be established.~
* exception support now implemented
* added example code to manually and minimally test `sadfs::inet::listener` and `sadfs::socket`

implements #15, and its parent #12 