### PR TITLE
fixed bugs in echod and msg + some behavioural changes

### DIFF
--- a/example/echod.cpp
+++ b/example/echod.cpp
@@ -10,14 +10,14 @@ main()
 {
 	using namespace sadfs;
 	auto listener = inet::listener{inet::constants::ip_localhost, 6666};
-	auto buf = std::array<char, 512>{};
-	auto len = 0;
+	auto buf = std::array<char, 64>{};
 
 	while (true)
 	{
 		auto sock = listener.accept();
 		std::cout << "accepted: " << sock.descriptor() << "\n";
 
+		auto len = 0;
 		while ((len = ::read(sock.descriptor(), buf.data(), buf.size())))
 		{
 			if (len == -1)
@@ -25,14 +25,18 @@ main()
 				std::cerr << "read error\n";
 				std::exit(1);
 			}
-			if (::write(sock.descriptor(), buf.data(), len) == -1)
+			if (len != ::write(sock.descriptor(), buf.data(), len))
 			{
 				std::cerr << "write error\n";
 				std::exit(1);
 			}
 
-			std::cout << buf.data() << "\n";
-			buf.fill({});
+			for (auto i = 0; i < len; i++)
+			{
+				std::cout << buf[i];
+				buf[i] = {};
+			}
 		}
+		std::cout << '\n';
 	}
 }

--- a/example/echod.cpp
+++ b/example/echod.cpp
@@ -15,7 +15,7 @@ main()
 	while (true)
 	{
 		auto sock = listener.accept();
-		std::cout << "accepted: " << sock.descriptor() << "\n";
+		std::cout << "accepted connection; fd: " << sock.descriptor() << "\n";
 
 		auto len = 0;
 		while ((len = ::read(sock.descriptor(), buf.data(), buf.size())))
@@ -25,18 +25,16 @@ main()
 				std::cerr << "read error\n";
 				std::exit(1);
 			}
+			std::cout << "received:    " << len << " byte(s)\n";
+
 			if (len != ::write(sock.descriptor(), buf.data(), len))
 			{
 				std::cerr << "write error\n";
 				std::exit(1);
 			}
-
-			for (auto i = 0; i < len; i++)
-			{
-				std::cout << buf[i];
-				buf[i] = {};
-			}
+			std::cout << "echoed back: " << len << " byte(s)\n";
+			buf.fill({}); // clear buffer
 		}
-		std::cout << '\n';
+		std::cout << "connection closed\n";
 	}
 }

--- a/example/msg.cpp
+++ b/example/msg.cpp
@@ -72,10 +72,10 @@ main(int argc, char** argv)
 		for (auto i = 0; i < recv_len; i++)
 		{
 			std::cout << buf[i];
-			buf[i] = {};
 		}
+		buf.fill({}); // clear buffer for next read
 	}
-	std::cout << '\n';
+	std::cout << "\n";
 
 	return 0;
 }

--- a/example/msg.cpp
+++ b/example/msg.cpp
@@ -9,10 +9,33 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+ssize_t
+len(char const* msg)
+{
+	constexpr auto max_len = 256;
+	auto len = std::strlen(msg);
+	if (len > max_len)
+	{
+		std::cerr << "msg length " << len << " exceeds limit of "
+		          << max_len << "\n";
+		std::exit(1);
+	}
+	return len;
+}
+
 int
 main(int argc, char** argv)
 {
 	using namespace sadfs;
+
+	if (argc > 2)
+	{
+		std::cout << "Usage: " << argv[0] << " [MSG]\n";
+		return 1;
+	}
+
+	auto const& msg = (argc == 2) ? argv[1] : "hi, there";
+	auto const msg_len = len(msg);
 
 	auto sock = sadfs::socket(socket::domain::inet, socket::type::stream);
 	auto addr = sockaddr_in{};
@@ -23,21 +46,36 @@ main(int argc, char** argv)
 	            reinterpret_cast<sockaddr const*>(&addr),
 	            sizeof(addr)) == -1)
 	{
-		return -1;
+		std::cerr << "error: could not connect to echo server\n";
+		std::exit(1);
 	}
 
-	char const* msg{(argc > 1) ? argv[1] : "hi, there"};
-	if (send(sock.descriptor(), msg, strlen(msg), 0) == -1)
+	if (send(sock.descriptor(), msg, msg_len, 0) != msg_len)
 	{
-		return -2;
+		std::cerr << "error: could not send message\n";
+		std::exit(1);
 	}
 
-	auto buf = std::array<char, 128>{};
-	if (recv(sock.descriptor(), buf.data(), buf.size(), 0) == -1)
+	auto buf = std::array<char, 64>{};
+	auto read_len = decltype(msg_len){0};
+	while (read_len < msg_len) // msg yet to be fully received
 	{
-		return -3;
+		auto recv_len = recv(sock.descriptor(),
+		                     buf.data(), buf.size(), 0);
+		if (recv_len == -1)
+		{
+			std::cerr << "error: could not receive echoed message\n";
+			std::exit(1);
+		}
+
+		read_len += recv_len;
+		for (auto i = 0; i < recv_len; i++)
+		{
+			std::cout << buf[i];
+			buf[i] = {};
+		}
 	}
-	std::cout << buf.data() << '\n';
+	std::cout << '\n';
 
 	return 0;
 }


### PR DESCRIPTION
* `msg` now correctly closes the connection upon receiving all data sent.
* `msg` now has a limit on the size of the message sent.
* reduced `echod` and `msg` buffer sizes to 64 -- obviously an inefficient thing to do, but it helps us visualize things better.

**NOTE:** these changes cannot be automatically merged, so we'll have to get our hands dirty a bit.