### PR TITLE
Create sadmd data structures, database and load database contents

### DIFF
--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -14,7 +14,8 @@ namespace sadfs {
 using chunkid = uint64_t;
 
 // all the information needed about a chunk server
-struct chunk_server_info{
+struct chunk_server_info
+{
 	inet::service service;
 	uint64_t max_chunks;
 	uint64_t chunk_count;
@@ -22,7 +23,8 @@ struct chunk_server_info{
 };
 
 // all the information needed about a file
-struct file_info{
+struct file_info
+{
 	int ttl;
 	std::vector<chunkid> chunkids;
 };
@@ -34,11 +36,14 @@ public:
 
 	// starts server
 	void start();
+
+private:
 	// creates (the metadata for) a new file
 	void create_file(std::string const&);
-private:
+
 	// loads file metadata from disk
 	void load_files();
+
 	// runs an sql statement on system_files_
 	void db_command(std::string const&) const noexcept;
 

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -25,8 +25,6 @@ struct chunk_server_info{
 struct file_info{
 	int ttl;
 	std::vector<chunkid> chunkids;
-	// decides whether file is currently locked for writing
-	bool locked();
 };
 
 class sadmd
@@ -39,24 +37,20 @@ public:
 	// creates (the metadata for) a new file
 	void create_file(std::string const&);
 private:
-	// reads the message from a socket that just received some data
-	std::string process_message(sadfs::socket const&);
 	// loads file metadata from disk
 	void load_files();
 	// runs an sql statement on system_files_
 	void db_command(std::string const&) const noexcept;
 
-	const inet::service service_;
+	inet::service const service_;
 	// in memory representation of each file
 	std::unordered_map<std::string, file_info> files_;
-	// list of active chunk servers
-	std::unordered_map<uint64_t, chunk_server_info> chunk_servers_;
+	// metadata for each chunk server
+	std::unordered_map<uint64_t, chunk_server_info> chunk_server_metadata_;
 	// map from chunkid to list of chunk servers
-	std::unordered_map<chunkid, std::vector<chunk_server_info*> > chunkids_;
+	std::unordered_map<chunkid, std::vector<chunk_server_info*> > chunk_locations_;
 	// persistent/on disk copy of files_
 	sqlite3* const files_db_;
-	sqlite3* open_db();
-
 };
 
 } // sadfs namespace

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -3,9 +3,29 @@
 #include <sadfs/comm/inet.hpp>
 #include <sadfs/comm/socket.hpp>
 
+#include <ctime>
 #include <string>
+#include <sqlite3.h>
+#include <unordered_map>
+#include <vector>
 
 namespace sadfs {
+
+// all the information needed about a chunk server
+struct chunk_server_info{
+	inet::ip_addr ip;
+	inet::port_no port;
+	int total_space;
+	int used_space;
+	time_t ttl;
+};
+
+// all the information needed about a file
+struct file_info{
+	bool locked;
+	time_t ttl;
+	std::vector<int> chunkids;
+};
 
 class sadmd
 {
@@ -14,11 +34,26 @@ public:
 
 	// starts server
 	void start();
+	// creates (the metadata for) a new file
+	void create_file(std::string);
 private:
 	// reads the message from a socket that just received some data
 	std::string process_message(sadfs::socket const&);
+	// loads file metadata from disk
+	void load_files();
+	// runs an sql statement on system_files_
+	void db_command(std::string);
 
 	inet::service const service_;
+	// in memory representation of each file
+	std::unordered_map<std::string, file_info> files_;
+	// list of active chunk servers
+	std::vector<chunk_server_info> active_chunk_servers_;
+	// map from chunkid to list of chunk servers
+	std::unordered_map<int, std::vector<chunk_server_info*> > chunkids_;
+	// persistent/on disk copy of files_
+	sqlite3* files_db_;
+
 };
 
 } // sadfs namespace

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -11,13 +11,13 @@
 
 namespace sadfs {
 
-using chunkid = unsigned int;
+using chunkid = uint64_t;
 
 // all the information needed about a chunk server
 struct chunk_server_info{
 	inet::service service;
-	unsigned int total_space;
-	unsigned int used_space;
+	uint64_t total_space;
+	uint64_t used_space;
 	int ttl;
 };
 
@@ -50,7 +50,7 @@ private:
 	// in memory representation of each file
 	std::unordered_map<std::string, file_info> files_;
 	// list of active chunk servers
-	std::unordered_map<unsigned int, chunk_server_info> chunk_servers_;
+	std::unordered_map<uint64_t, chunk_server_info> chunk_servers_;
 	// map from chunkid to list of chunk servers
 	std::unordered_map<chunkid, std::vector<chunk_server_info*> > chunkids_;
 	// persistent/on disk copy of files_

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -16,8 +16,8 @@ using chunkid = uint64_t;
 // all the information needed about a chunk server
 struct chunk_server_info{
 	inet::service service;
-	uint64_t total_space;
-	uint64_t used_space;
+	uint64_t max_chunks;
+	uint64_t number_stored_chunks;
 	int ttl;
 };
 

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -17,7 +17,7 @@ using chunkid = uint64_t;
 struct chunk_server_info{
 	inet::service service;
 	uint64_t max_chunks;
-	uint64_t number_stored_chunks;
+	uint64_t chunk_count;
 	int ttl;
 };
 

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -50,7 +50,7 @@ private:
 	// in memory representation of each file
 	std::unordered_map<std::string, file_info> files_;
 	// list of active chunk servers
-	std::vector<chunk_server_info> chunk_servers_;
+	std::unordered_map<unsigned int, chunk_server_info> chunk_servers_;
 	// map from chunkid to list of chunk servers
 	std::unordered_map<chunkid, std::vector<chunk_server_info*> > chunkids_;
 	// persistent/on disk copy of files_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable (sadmd
 	sadmd/main.cpp
 	sadmd/sadmd.cpp
 	${COMMON_SOURCE_FILES})
+target_link_libraries(sadmd
+	sqlite3)
 add_executable (sadcd
 	sadcd/main.cpp
 	sadcd/sadcd.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,8 +30,6 @@ add_executable (sadmd
 	sadmd/main.cpp
 	sadmd/sadmd.cpp
 	${COMMON_SOURCE_FILES})
-target_link_libraries(sadmd
-	sqlite3)
 add_executable (sadcd
 	sadcd/main.cpp
 	sadcd/sadcd.cpp
@@ -39,6 +37,9 @@ add_executable (sadcd
 # add_executable (sadfsd
 #	sadfsd/sadfsd.cpp
 #	${COMMON_SOURCE_FILES})
+
+target_link_libraries(sadmd
+	sqlite3)
 
 # first, find the boost_program_options library. this sets
 # the Boost_INCLUDE_DIRS and Boost_LIBRARIES variables

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -112,14 +112,13 @@ void sadmd::
 load_files()
 {
 	std::cout << "Files loaded:\n";
-	auto res = 0;
 	sqlite3_stmt* stmt;
 	if (sqlite3_prepare_v2(files_db_, "SELECT * FROM files;", -1, &stmt, NULL) != 0)
 	{
 		std::cerr << sqlite3_errmsg(files_db_) << '\n';
 	}
 
-	while ((res = sqlite3_step(stmt)) == SQLITE_ROW)
+	while (sqlite3_step(stmt) == SQLITE_ROW)
 	{
 		auto filename = std::string{reinterpret_cast<const char*>(
 			sqlite3_column_text(stmt, 0))};

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h> // read/write
 
 namespace {
+
 sqlite3*
 open_db()
 {
@@ -27,7 +28,7 @@ open_db()
 	}
 	return db;
 }
-	
+
 std::string
 process_message(sadfs::socket const& sock)
 {
@@ -93,7 +94,9 @@ create_file(std::string const& filename)
 	}
 	else
 	{
+		// TODO: give a more meaningful error message to the user
 		std::cerr << "Error: " << filename << ": file already exists\n";
+		std::exit(1);
 	}
 	
 }
@@ -117,6 +120,7 @@ load_files()
 	if (sqlite3_prepare_v2(files_db_, "SELECT * FROM files;", -1, &stmt, NULL) != 0)
 	{
 		std::cerr << sqlite3_errmsg(files_db_) << '\n';
+		std::exit(1);
 	}
 
 	while (sqlite3_step(stmt) == SQLITE_ROW)


### PR DESCRIPTION
The exact info sadmd keeps about files and chunk servers is based on what is currently in ideas.md but will likely change and it should be straigtforward to do so.

If you manuallly add some rows to the database this will print the filenames and chunkid lists as there is no other way to verify that this works but these print statements should be removed once there is some more functionality associated with the files_ object

Closes #28 