### PR TITLE
to_string and to_int helper functions for ip_addr and port_no

### DIFF
--- a/include/sadfs/comm/inet.hpp
+++ b/include/sadfs/comm/inet.hpp
@@ -5,7 +5,9 @@
 #include "socket.hpp"
 
 // standard includes
-#include <cstdint> // std::uint32_t, std::uint16_t
+#include <arpa/inet.h> // inet_ntoa, ntohs
+#include <cstdint>     // std::uint32_t, std::uint16_t
+#include <string>
 
 namespace sadfs { namespace comm {
 
@@ -24,6 +26,13 @@ private:
 	std::uint32_t const value_;
 };
 
+// returns the dotted-decimal representation of ip
+inline std::string
+to_string(ip_addr const& ip)
+{
+	return inet_ntoa({ip.value()});
+}
+
 // represents a port number
 class port_no
 {
@@ -34,6 +43,13 @@ public:
 private:
 	std::uint16_t const value_;
 };
+
+// returns the int representation of port
+inline int
+to_int(port_no const& port) noexcept
+{
+	return ntohs(port.value());
+}
 
 // represents a service on a host,
 // specified by an IP + port number

--- a/src/comm/inet.cpp
+++ b/src/comm/inet.cpp
@@ -5,7 +5,7 @@
 #include <sadfs/comm/defaults.hpp>
 
 // standard includes
-#include <arpa/inet.h>  // inet_aton, inet_ntoa, htons, ntohs
+#include <arpa/inet.h>  // inet_aton, htons
 #include <cerrno>       // errno
 #include <limits>       // std::numeric_limits
 #include <netinet/in.h> // in_addr
@@ -22,8 +22,8 @@ namespace {
 auto fmt_err = [](char const* msg, ip_addr const& ip, port_no const& port)
 {
 	return ""s // explicitly tell the compiler that we want a string
-	       + msg + inet_ntoa({ip.value()}) + ":"
-	       + std::to_string(ntohs(port.value()));
+	       + msg + to_string(ip) + ":"
+	       + std::to_string(to_int(port));
 };
 
 // verifies that an ip address in string format is valid,
@@ -46,7 +46,8 @@ parse_port_no(int port)
 {
 	if (port > std::numeric_limits<std::uint16_t>::max())
 	{
-		throw std::invalid_argument("invalid port number");
+		throw std::invalid_argument("invalid port number: "
+		                            + std::to_string(port));
 	}
 	return htons(static_cast<std::uint16_t>(port));
 }


### PR DESCRIPTION
- these will make sending and receiving ip + port number via control messages, easier to implement
- print a more meaningful error message when using an invalid port number is attempted