### PR TITLE
implemented control message header containing host-id

### DIFF
--- a/example/dummy-sadcd.cpp
+++ b/example/dummy-sadcd.cpp
@@ -2,6 +2,8 @@
 #include <sadfs/comm/inet.hpp>
 #include <sadfs/logger.hpp>
 #include <sadfs/sadcd/heart.hpp>
+#include <sadfs/types.hpp>
+#include <sadfs/uuid.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -11,9 +13,11 @@
 using namespace sadfs;
 struct sadcd
 {
+    serverid id;
+    sadcd() : id{serverid::generate()} {}
     void run(comm::service const &master)
     {
-        auto heart = chunk::heart{master};
+        auto heart = chunk::heart{master, id};
         logger::debug("starting heartbeat...");
         heart.start();
         logger::debug("started");

--- a/example/dummy-sadmd.cpp
+++ b/example/dummy-sadmd.cpp
@@ -49,8 +49,11 @@ struct sadmd
     }
 
     using clr = msgs::master::chunk_location_request;
-    bool handle(clr const &req, msgs::channel const &ch)
+    bool handle(clr const &req, msgs::message_header const &header,
+                msgs::channel const &ch)
     {
+        logger::debug(std::string_view{"received req. from: " +
+                                       to_string(header.host_id)});
         auto response = msgs::client::chunk_location_response{
             /*ok=*/true,
             {{"10.0.0.13", 6666}},
@@ -63,8 +66,11 @@ struct sadmd
     }
 
     using hb = msgs::master::chunk_server_heartbeat;
-    bool handle(hb const &hb, msgs::channel const &ch)
+    bool handle(hb const &hb, msgs::message_header const &header,
+                msgs::channel const &ch)
     {
+        logger::debug(std::string_view{"received req. from: " +
+                                       to_string(header.host_id)});
         auto response = msgs::chunk::acknowledgement{/*ok=*/true};
         auto result   = msgs::chunk::serializer{}.serialize(response, ch);
         ch.flush();

--- a/include/sadfs/msgs/common.hpp
+++ b/include/sadfs/msgs/common.hpp
@@ -3,6 +3,7 @@
 
 // sadfs-specific includes
 #include <sadfs/proto/common.pb.h>
+#include <sadfs/uuid.hpp>
 
 // standard includes
 #include <cstddef> // std::size_t
@@ -20,10 +21,10 @@ enum class io_type
     write,
 };
 
-// uniquely identifies a host
-struct host_id
+// header of every control message
+struct message_header
 {
-    std::size_t uuid;
+    uuid host_id;
 };
 
 using io_type_map       = std::unordered_map<proto::io_type, io_type>;

--- a/include/sadfs/msgs/deserializer_impl.hpp
+++ b/include/sadfs/msgs/deserializer_impl.hpp
@@ -8,56 +8,58 @@
 // external includes
 #include <google/protobuf/util/delimited_message_util.h>
 
-namespace sadfs { namespace msgs {
+namespace sadfs
+{
+namespace msgs
+{
 
 // Container refers to a container for control messages
-template <typename Container>
-class deserializer
+template <typename Container> class deserializer
 {
 public:
-	deserializer() = default; // TODO: remove
-	deserializer(host_id id);
+    deserializer() = default; // TODO: remove
 
-	template <typename ControlMessage>
-	std::pair<bool, bool> deserialize(ControlMessage&, channel const&);
+    template <typename ControlMessage>
+    std::pair<bool, bool> deserialize(ControlMessage &, channel const &);
 
 protected:
-	using container_type = Container;
-	Container container_{};
+    using container_type = Container;
+    Container container_{};
 
 private:
-	friend class msgs::channel;
-	std::pair<bool, bool> deserialize(gpio::ZeroCopyInputStream*);
+    friend class msgs::channel;
+    std::pair<bool, bool> deserialize(gpio::ZeroCopyInputStream *);
 };
 
 // template definitions
 template <typename Container>
 template <typename ControlMessage>
-std::pair<bool, bool> msgs::deserializer<Container>::
-deserialize(ControlMessage& cm, channel const& ch)
+std::pair<bool, bool>
+msgs::deserializer<Container>::deserialize(ControlMessage &cm,
+                                           channel const & ch)
 {
-	auto res =  ch.accept_deserializer(*this);
-	res.first = res.first && extract(cm, container_);
+    auto res  = ch.accept_deserializer(*this);
+    res.first = res.first && extract(cm, container_);
 
-	// we must not hold data after deserialization
-	container_.clear_msg();
-	return res;
+    // we must not hold data after deserialization
+    container_.clear_msg();
+    return res;
 }
 
 template <typename Container>
-std::pair<bool, bool> deserializer<Container>::
-deserialize(gpio::ZeroCopyInputStream* in)
+std::pair<bool, bool>
+deserializer<Container>::deserialize(gpio::ZeroCopyInputStream *in)
 {
-	namespace gputil = google::protobuf::util;
-	auto const deserialize = gputil::ParseDelimitedFromZeroCopyStream;
+    namespace gputil       = google::protobuf::util;
+    auto const deserialize = gputil::ParseDelimitedFromZeroCopyStream;
 
-	auto result = false, eof = false;
-	result = deserialize(&container_, in, &eof);
+    auto result = false, eof = false;
+    result = deserialize(&container_, in, &eof);
 
-	return {result, eof};
+    return {result, eof};
 }
 
-} // msgs namespace
-} // sadfs namespace
+} // namespace msgs
+} // namespace sadfs
 
 #endif // SADFS_MSGS_DESERIALIZERS_HPP

--- a/include/sadfs/msgs/serializer_impl.hpp
+++ b/include/sadfs/msgs/serializer_impl.hpp
@@ -5,52 +5,69 @@
 #include <sadfs/msgs/channel.hpp>
 #include <sadfs/msgs/common.hpp>
 
+// standard includes
+#include <iterator>
+
 // external includes
 #include <google/protobuf/util/delimited_message_util.h>
 
-namespace sadfs { namespace msgs {
+namespace sadfs
+{
+namespace msgs
+{
 
 // Container refers to a container for control messages
-template <typename Container>
-class serializer
+template <typename Container> class serializer
 {
 public:
-	serializer() = default; // TODO: remove
-	serializer(host_id id);
+    serializer() = default; // TODO: remove
+    serializer(message_header header);
 
-	template <typename ControlMessage>
-	bool serialize(ControlMessage const&, channel const&);
+    template <typename ControlMessage>
+    bool serialize(ControlMessage const &, channel const &);
 
 private:
-	Container container_{};
+    Container      container_{};
+    message_header header_{};
 
-	friend class msgs::channel;
-	bool serialize(gpio::ZeroCopyOutputStream*) const;
+    friend class msgs::channel;
+    bool serialize(gpio::ZeroCopyOutputStream *) const;
 };
 
 // template definitions
 template <typename Container>
 template <typename ControlMessage>
-bool msgs::serializer<Container>::
-serialize(ControlMessage const& cm, channel const& ch)
+bool
+msgs::serializer<Container>::serialize(ControlMessage const &cm,
+                                       channel const &       ch)
 {
-	auto res = embed(cm, container_) && ch.accept_serializer(*this);
-	// we must not hold data after serialization
-	container_.clear_msg();
-	return res;
+    header_.host_id.serialize(
+        std::back_inserter(*container_.mutable_header()->mutable_host_id()));
+    auto res = embed(cm, container_) && ch.accept_serializer(*this);
+
+    // we must not hold data after serialization
+    container_.clear_msg();
+    return res;
 }
 
 template <typename Container>
-bool serializer<Container>::
-serialize(gpio::ZeroCopyOutputStream* out) const
+bool
+serializer<Container>::serialize(gpio::ZeroCopyOutputStream *out) const
 {
-	namespace gputil = google::protobuf::util;
-	auto const serialize = gputil::SerializeDelimitedToZeroCopyStream;
+    namespace gputil     = google::protobuf::util;
+    auto const serialize = gputil::SerializeDelimitedToZeroCopyStream;
 
-	return serialize(container_, out);
+    return serialize(container_, out);
 }
 
-} // msgs namespace
-} // sadfs namespace
+// inline definitions
+template <typename Container>
+inline serializer<Container>::serializer(message_header header)
+    : header_{std::move(header)}
+{
+}
+
+} // namespace msgs
+} // namespace sadfs
 
 #endif // SADFS_MSGS_SERIALIZERS_HPP

--- a/include/sadfs/sadcd/heart.hpp
+++ b/include/sadfs/sadcd/heart.hpp
@@ -3,6 +3,7 @@
 
 // sadfs-specific includes
 #include <sadfs/comm/inet.hpp> // comm::service
+#include <sadfs/types.hpp>
 
 // standard includes
 #include <chrono>
@@ -18,12 +19,18 @@ namespace chunk
 class heart
 {
     comm::service      master_;
+    serverid           host_id_;
     std::thread        heartbeat_{};
     std::promise<void> stop_request_;
     std::future<void>  stopped_;
 
+    void beat(std::promise<void>, std::future<void>);
+
 public:
-    heart(comm::service const &master) : master_{master} {}
+    heart(comm::service const &master, serverid id)
+        : master_{master}, host_id_{id}
+    {
+    }
     ~heart();
 
     void start();

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -18,108 +18,111 @@
 #include <unordered_map>
 #include <vector>
 
-namespace sadfs {
+namespace sadfs
+{
 
 using time_point = std::chrono::steady_clock::rep;
 
 // all the information needed about a chunk server
 struct chunk_server_info
 {
-	comm::service service;
-	uint64_t max_chunks;
-	uint64_t chunk_count;
-	time_point valid_until;
+    comm::service service;
+    uint64_t      max_chunks;
+    uint64_t      chunk_count;
+    time_point    valid_until;
 };
 
 // all the information needed about a file
 struct file_info
 {
-	int ttl;
-	util::file_chunks chunkids;
-	uint32_t size;
+    int               ttl;
+    util::file_chunks chunkids;
+    uint32_t          size;
 };
 
 // all the information needed about a chunk
 struct chunk_info
 {
-	version latest_version;
-	// all the places this chunk is stored and what version is there
-	std::unordered_map<serverid, version> locations;
+    version latest_version;
+    // all the places this chunk is stored and what version is there
+    std::unordered_map<serverid, version> locations;
 };
 
 class sadmd
 {
 public:
-	sadmd(char const* ip, int port);
+    sadmd(char const *ip, int port);
 
-	// starts server
-	void start();
+    // starts server
+    void start();
 
-	// handles a chunk_write_notification
-	bool handle(msgs::master::chunk_write_notification const&, 
-                msgs::channel const&);
+    // handles a chunk_write_notification
+    bool handle(msgs::master::chunk_write_notification const &,
+                msgs::message_header const &, msgs::channel const &);
 
-	// handles a chunk_location_request and responds to channel it came in on
-	bool handle(msgs::master::chunk_location_request const&, 
-                msgs::channel const&);
+    // handles a chunk_location_request and responds to channel it came in on
+    bool handle(msgs::master::chunk_location_request const &,
+                msgs::message_header const &, msgs::channel const &);
 
-	// handles a chunk_server_hearbeat
-	/* TODO
-	bool handle(msgs::master::chunk_server_heartbeat const&, 
-                msgs::channel const&);
-	*/
+    // handles a chunk_server_hearbeat
+    /* TODO
+    bool handle(msgs::master::chunk_server_heartbeat const&,
+                msgs::message_header const&,
+            msgs::channel const&);
+    */
 
-	// handles a join_network_request and responds to channel it came in on
-	bool handle(msgs::master::join_network_request const&, 
-                msgs::channel const&);
+    // handles a join_network_request and responds to channel it came in on
+    bool handle(msgs::master::join_network_request const &,
+                msgs::message_header const &, msgs::channel const &);
+
 private:
-	// takes ownership of a channel and serves the request on it
-	void serve_requests(msgs::channel);
+    // takes ownership of a channel and serves the request on it
+    void serve_requests(msgs::channel);
 
-	// creates (the metadata for) a new file
-	void create_file(std::string const&);
+    // creates (the metadata for) a new file
+    void create_file(std::string const &);
 
-	// loads file metadata from disk
-	void load_files();
-	void load_file(std::string const&, std::string const&);
+    // loads file metadata from disk
+    void load_files();
+    void load_file(std::string const &, std::string const &);
 
-	// copies in-memory files into database
-	void save_files() const noexcept;
+    // copies in-memory files into database
+    void save_files() const noexcept;
 
-	// runs an sql statement on system_files_
-	void db_command(std::string const&) const;
+    // runs an sql statement on system_files_
+    void db_command(std::string const &) const;
 
-	// returns true if the database contains a file with the given name
-	bool db_contains(std::string const&) const;
+    // returns true if the database contains a file with the given name
+    bool db_contains(std::string const &) const;
 
-	// functions for maintaining chunk servers 
+    // functions for maintaining chunk servers
 
-	void append_chunk_to_file(std::string const&, chunkid);
+    void append_chunk_to_file(std::string const &, chunkid);
 
-	bool add_chunk_to_server(chunkid, version, serverid);
+    bool add_chunk_to_server(chunkid, version, serverid);
 
-	void reintroduce_chunks_to_network(util::file_chunks);
+    void reintroduce_chunks_to_network(util::file_chunks);
 
-	// must be a class member to have access to chunk_metadata_
-	std::vector<comm::service> valid_servers(chunk_info&, bool);
+    // must be a class member to have access to chunk_metadata_
+    std::vector<comm::service> valid_servers(chunk_info &, bool);
 
-	// returns true on success
-	bool add_server_to_network(serverid, comm::service, uint64_t, uint64_t);
-	void remove_server_from_network(serverid) noexcept;
-	void register_server_heartbeat(serverid) noexcept;
-	bool is_active(serverid) const noexcept;
+    // returns true on success
+    bool add_server_to_network(serverid, comm::service, uint64_t, uint64_t);
+    void remove_server_from_network(serverid) noexcept;
+    void register_server_heartbeat(serverid) noexcept;
+    bool is_active(serverid) const noexcept;
 
-	comm::service const service_;
-	// in memory representation of each file
-	std::unordered_map<std::string, file_info> files_;
-	// metadata for each chunk server
-	std::unordered_map<serverid, chunk_server_info> chunk_server_metadata_;
-	// map from chunkid to chunk info
-	std::unordered_map<chunkid, chunk_info> chunk_metadata_;
-	// persistent/on disk copy of files_
-	sqlite3* const files_db_;
+    comm::service const service_;
+    // in memory representation of each file
+    std::unordered_map<std::string, file_info> files_;
+    // metadata for each chunk server
+    std::unordered_map<serverid, chunk_server_info> chunk_server_metadata_;
+    // map from chunkid to chunk info
+    std::unordered_map<chunkid, chunk_info> chunk_metadata_;
+    // persistent/on disk copy of files_
+    sqlite3 *const files_db_;
 };
 
-} // sadfs namespace
+} // namespace sadfs
 
 #endif // SADFS_SADMD_SADMD_HPP

--- a/src/proto/chunk.proto
+++ b/src/proto/chunk.proto
@@ -11,7 +11,7 @@ message chunk_request {
 
 // container for control messages
 message message_container {
-	sadfs.proto.host_id sender = 1;
+	sadfs.proto.header  header = 1;
 	oneof               msg {
 		sadfs.proto.acknowledgement ack       = 6;
 		chunk_request               chunk_req = 7;

--- a/src/proto/client.proto
+++ b/src/proto/client.proto
@@ -14,7 +14,7 @@ message chunk_location_response {
 
 // container for all control messages sent to clients
 message message_container {
-	sadfs.proto.host_id sender = 1;
+	sadfs.proto.header  header = 1;
 	oneof               msg {
 		chunk_location_response chunk_location_res = 11;
 	}

--- a/src/proto/common.proto
+++ b/src/proto/common.proto
@@ -8,8 +8,8 @@ enum io_type {
 	WRITE   = 2;
 }
 
-message host_id {
-	uint64 id = 1;
+message header {
+	bytes host_id = 1;
 }
 
 // generic acknowledgement message

--- a/src/proto/master.proto
+++ b/src/proto/master.proto
@@ -35,7 +35,7 @@ message join_network_request {
 
 // container for control messages
 message message_container {
-	sadfs.proto.host_id sender = 1;
+	sadfs.proto.header  header = 1;
 	oneof               msg {
 	    chunk_write_notification chunk_write_notify     = 10;
 		chunk_location_request   chunk_location_req     = 11;

--- a/src/sadcd/sadcd.cpp
+++ b/src/sadcd/sadcd.cpp
@@ -69,7 +69,7 @@ sadcd::run()
     }
 
     // start heartbeat
-    auto heart = chunk::heart{master_};
+    auto heart = chunk::heart{master_, serverid_};
     heart.start();
 
     // poll for failures
@@ -124,10 +124,12 @@ sadcd::join_network()
     return true;
 }
 
-bool sadcd::
-notify_master_of_write(chunkid chunk, version version_num, std::string const& filename, uint32_t new_chunk_size)
+bool
+sadcd::notify_master_of_write(chunkid chunk, version version_num,
+                              std::string const &filename,
+                              uint32_t           new_chunk_size)
 {
-	auto sock = master_.connect();
+    auto sock = master_.connect();
     if (!sock.valid())
     {
         return false;
@@ -135,18 +137,12 @@ notify_master_of_write(chunkid chunk, version version_num, std::string const& fi
 
     auto ch = msgs::channel{std::move(sock)};
 
-	auto cwn = msgs::master::chunk_write_notification
-	{
-		serverid_,
-		chunk,
-		version_num,
-		filename,
-		new_chunk_size
-	};
+    auto cwn = msgs::master::chunk_write_notification{
+        serverid_, chunk, version_num, filename, new_chunk_size};
 
-	msgs::master::serializer{}.serialize(cwn, ch);
-	// TODO: confirm from master that the write went through
-	return true;
+    msgs::master::serializer{}.serialize(cwn, ch);
+    // TODO: confirm from master that the write went through
+    return true;
 }
 
 } // namespace sadfs

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -11,26 +11,30 @@
 
 // standard includes
 #include <array>
-#include <cstring>  // std::strerror
+#include <cstring> // std::strerror
 #include <functional>
 #include <iostream>
 #include <iterator>
 #include <sstream>  // std::osstream
 #include <unistd.h> // read/write
 
-namespace sadfs {
+namespace sadfs
+{
 
-namespace {
-namespace constants {
+namespace
+{
+namespace constants
+{
 
 // columns in our SQLite database
-constexpr auto filename_col = 0;
+constexpr auto filename_col    = 0;
 constexpr auto chunkid_str_col = 1;
 constexpr auto bytes_per_chunk = 64 * 1024 * 1024; // 64 MB
 
-} // (local) constants namespace
+} // namespace constants
 
-namespace time {
+namespace time
+{
 
 using namespace std::literals;
 constexpr auto server_ttl = 1min;
@@ -39,410 +43,402 @@ constexpr auto file_ttl   = 1min;
 time_point
 from_now(std::chrono::minutes delta) noexcept
 {
-	return (std::chrono::steady_clock::now() + delta).time_since_epoch().count();
+    return (std::chrono::steady_clock::now() + delta)
+        .time_since_epoch()
+        .count();
 }
 
-time_point 
+time_point
 now() noexcept
 {
-	// the time point zero minutes from now is, you guessed it, now
-	return from_now(0min);
+    // the time point zero minutes from now is, you guessed it, now
+    return from_now(0min);
 }
-} // time namespace
+} // namespace time
 
-sqlite3*
+sqlite3 *
 open_db()
 {
-	sqlite3* db;
+    sqlite3 *db;
 
-	// open the sadmd database
-	if (sqlite3_open("sadmd.db", &db) != 0)
-	{
-		std::cerr << "Error: Couldn't open database: ";
-		std::cerr << sqlite3_errmsg(db) << '\n';
-		std::exit(1);
-	}
-	return db;
+    // open the sadmd database
+    if (sqlite3_open("sadmd.db", &db) != 0)
+    {
+        std::cerr << "Error: Couldn't open database: ";
+        std::cerr << sqlite3_errmsg(db) << '\n';
+        std::exit(1);
+    }
+    return db;
 }
 } // unnamed namespace
 
-std::vector<comm::service> sadmd::
-valid_servers(chunk_info& info, bool latest_only)
+std::vector<comm::service>
+sadmd::valid_servers(chunk_info &info, bool latest_only)
 {
-	auto is_active_latest_version = [&info](auto version, auto valid_until){ 
-		return valid_until > time::now() && 
-		       version == info.latest_version;
-	};
-	auto filter = [&](auto version, auto valid_until)
-	{
-		if (latest_only) { return is_active_latest_version(version, valid_until); }
-		return valid_until > time::now();
-	};
+    auto is_active_latest_version = [&info](auto version, auto valid_until) {
+        return valid_until > time::now() && version == info.latest_version;
+    };
+    auto filter = [&](auto version, auto valid_until) {
+        if (latest_only)
+        {
+            return is_active_latest_version(version, valid_until);
+        }
+        return valid_until > time::now();
+    };
 
-	auto services = std::vector<comm::service>{};
-	services.reserve(info.locations.size());
-	for (auto location : info.locations)
-	{
-		auto server = chunk_server_metadata_.at(location.first);
-		if (filter(location.second/*=version*/, server.valid_until))
-		{
-			services.push_back(server.service);
-		}
-	}
-	return services;
+    auto services = std::vector<comm::service>{};
+    services.reserve(info.locations.size());
+    for (auto location : info.locations)
+    {
+        auto server = chunk_server_metadata_.at(location.first);
+        if (filter(location.second /*=version*/, server.valid_until))
+        {
+            services.push_back(server.service);
+        }
+    }
+    return services;
 }
 
-sadmd::
-sadmd(char const* ip, int port) : service_(ip, port) , files_db_(open_db())
+sadmd::sadmd(char const *ip, int port)
+    : service_(ip, port), files_db_(open_db())
 {
-	// make sure the files table exists
-	db_command("CREATE TABLE IF NOT EXISTS files (filename TEXT, chunkids TEXT);");
-	// load files from the database to in-memory representation
-	load_files();
+    // make sure the files table exists
+    db_command(
+        "CREATE TABLE IF NOT EXISTS files (filename TEXT, chunkids TEXT);");
+    // load files from the database to in-memory representation
+    load_files();
 }
 
-void sadmd::
-start()
+void
+sadmd::start()
 {
-	create_file("/mnt/a/file.dat");
-	auto listener = comm::listener{service_};
-	while (true)
-	{
-		auto sock = listener.accept();
-		serve_requests(std::move(sock));
-	}
+    create_file("/mnt/a/file.dat");
+    auto listener = comm::listener{service_};
+    while (true)
+    {
+        auto sock = listener.accept();
+        serve_requests(std::move(sock));
+    }
 }
 
-void sadmd::
-serve_requests(msgs::channel ch)
+void
+sadmd::serve_requests(msgs::channel ch)
 {
-	auto processor = msgs::master::processor{};
-	bool result{false}, eof{false};
-	while (true)
-	{
-		auto [result, eof] = processor.process_next(ch, *this);
-		if (result)
-		{
-			//std::cout << "request served successfully\n";
-		}
-		else if (eof)
-		{
-			//std::cout << "EOF\n";
-			break;
-		}
-		else
-		{
-			std::cerr << "Error: request service failed\n";
-		}
-	}
+    auto processor = msgs::master::processor{};
+    bool result{false}, eof{false};
+    while (true)
+    {
+        auto [result, eof] = processor.process_next(ch, *this);
+        if (result)
+        {
+            // std::cout << "request served successfully\n";
+        }
+        else if (eof)
+        {
+            // std::cout << "EOF\n";
+            break;
+        }
+        else
+        {
+            std::cerr << "Error: request service failed\n";
+        }
+    }
 }
 
-bool sadmd::
-handle(msgs::master::chunk_location_request const& clr, msgs::channel const& ch)
+bool
+sadmd::handle(msgs::master::chunk_location_request const &clr,
+              msgs::message_header const &, msgs::channel const &ch)
 {
-	auto id = chunkid{};
-	auto servers = std::vector<comm::service>{};
-	auto const& filename = clr.filename();
-	auto version_num = version{0};
+    auto        id          = chunkid{};
+    auto        servers     = std::vector<comm::service>{};
+    auto const &filename    = clr.filename();
+    auto        version_num = version{0};
 
-	// lambda to check if a chunk number is valid for filename
-	auto validate = [&filename](auto it, auto chunk_number)
-	{
-		 // safe since we don't validate if iterator is invalid
-		if (chunk_number >= it->second.chunkids.size())
-		{
-			std::cerr << "Error: request for too large chunk number: chunk "
-					<< chunk_number
-					<< " of "
-					<< filename
-					<< '\n';
-			return false;
-		}
-		return true;
-	};
+    // lambda to check if a chunk number is valid for filename
+    auto validate = [&filename](auto it, auto chunk_number) {
+        // safe since we don't validate if iterator is invalid
+        if (chunk_number >= it->second.chunkids.size())
+        {
+            std::cerr << "Error: request for too large chunk number: chunk "
+                      << chunk_number << " of " << filename << '\n';
+            return false;
+        }
+        return true;
+    };
 
-	// look up relevant info
-	auto it = files_.find(filename);
-	if (it == files_.end())
-	{
-		std::cerr << "Error: request for chunk location in nonexistant file "
-				  << filename
-				  << '\n';
-	}
-	else if (validate(it, clr.chunk_number()))
-	{
-		id = it->second.chunkids[clr.chunk_number()];
-		auto& chunk = chunk_metadata_[id];
-		servers = valid_servers(chunk, 
-				/*latest_only=*/clr.io_type() == sadfs::msgs::io_type::read); 
-		version_num = chunk.latest_version;
-		if (servers.size() <= 0)
-		{
-			std::cerr << "Error: list of server locations empty\n";
-		}
-	}
-		
-	// create the response protobuf
-	auto response = msgs::client::chunk_location_response
-	{
-		servers.size() > 0,
-		servers,
-		id,
-		version_num
-	};
+    // look up relevant info
+    auto it = files_.find(filename);
+    if (it == files_.end())
+    {
+        std::cerr << "Error: request for chunk location in nonexistant file "
+                  << filename << '\n';
+    }
+    else if (validate(it, clr.chunk_number()))
+    {
+        id          = it->second.chunkids[clr.chunk_number()];
+        auto &chunk = chunk_metadata_[id];
+        servers     = valid_servers(chunk,
+                                /*latest_only=*/clr.io_type() ==
+                                    sadfs::msgs::io_type::read);
+        version_num = chunk.latest_version;
+        if (servers.size() <= 0)
+        {
+            std::cerr << "Error: list of server locations empty\n";
+        }
+    }
 
-	// send protobuf back over channel
-	auto result = msgs::client::serializer{}.serialize(response, ch);
-	ch.flush();
-	return result;
+    // create the response protobuf
+    auto response = msgs::client::chunk_location_response{
+        servers.size() > 0, servers, id, version_num};
+
+    // send protobuf back over channel
+    auto result = msgs::client::serializer{}.serialize(response, ch);
+    ch.flush();
+    return result;
 }
 
-bool sadmd::
-handle(msgs::master::join_network_request const& jnr, msgs::channel const& ch)
+bool
+sadmd::handle(msgs::master::join_network_request const &jnr,
+              msgs::message_header const &, msgs::channel const &ch)
 {
-	add_server_to_network(jnr.server_id(), 
-						  jnr.service(),
-						  jnr.max_chunks(), 
-						  jnr.chunk_count());
-	return true;
+    add_server_to_network(jnr.server_id(), // header.host_id,
+                          jnr.service(), jnr.max_chunks(), jnr.chunk_count());
+    return true;
 }
 
-bool sadmd::
-handle(msgs::master::chunk_write_notification const& cwn, msgs::channel const& ch)
+bool
+sadmd::handle(msgs::master::chunk_write_notification const &cwn,
+              msgs::message_header const &, msgs::channel const &ch)
 {
-	auto server = cwn.server_id();
-	if (!is_active(server)) return false;
-  
-	auto chunk = cwn.chunk_id();
-	// should update the size IF this is the latest version of the last chunk in the file
-	auto update_size = false;
+    auto server = cwn.server_id(); // header.host_id;
+    if (!is_active(server))
+        return false;
 
-	auto it = chunk_metadata_.end();
-	if ((it = chunk_metadata_.find(chunk)) != chunk_metadata_.end())
-	{
-		// chunk is already registerd - update version info
-		auto& info = it->second;
-		info.latest_version = std::max<version>(info.latest_version, cwn.version());
-		auto location = info.locations.end();
-		if ((location = info.locations.find(server)) != info.locations.end())
-		{
-			// chunk was already stored on this server - update version info
-			info.locations[server] = cwn.version();
-		}
-		else
-		{
-			// chunk was not previously on this server
-			add_chunk_to_server(chunk, cwn.version(), server);
-		}
-		update_size = info.latest_version == cwn.version();
-	}
-	else
-	{
-		// new chunk - add to file and record its location
-		if (add_chunk_to_server(chunk, cwn.version(), server))
-		{
-			append_chunk_to_file(cwn.filename(), chunk);
-			update_size = true;
-		}
-	}
-	if (update_size){
-		auto& file_info_ = files_[cwn.filename()];
-		auto num_chunks = file_info_.chunkids.size();
-		// check that this is the last chunk in the file
-		if (chunk == file_info_.chunkids[num_chunks - 1])
-		{
-			file_info_.size = ((num_chunks - 1) * constants::bytes_per_chunk) 
-                              + cwn.new_size();
-		}
-	}
-	
-	return true;
+    auto chunk = cwn.chunk_id();
+    // should update the size IF this is the latest version of the last chunk
+    // in the file
+    auto update_size = false;
+
+    auto it = chunk_metadata_.end();
+    if ((it = chunk_metadata_.find(chunk)) != chunk_metadata_.end())
+    {
+        // chunk is already registerd - update version info
+        auto &info = it->second;
+        info.latest_version =
+            std::max<version>(info.latest_version, cwn.version());
+        auto location = info.locations.end();
+        if ((location = info.locations.find(server)) != info.locations.end())
+        {
+            // chunk was already stored on this server - update version info
+            info.locations[server] = cwn.version();
+        }
+        else
+        {
+            // chunk was not previously on this server
+            add_chunk_to_server(chunk, cwn.version(), server);
+        }
+        update_size = info.latest_version == cwn.version();
+    }
+    else
+    {
+        // new chunk - add to file and record its location
+        if (add_chunk_to_server(chunk, cwn.version(), server))
+        {
+            append_chunk_to_file(cwn.filename(), chunk);
+            update_size = true;
+        }
+    }
+    if (update_size)
+    {
+        auto &file_info_ = files_[cwn.filename()];
+        auto  num_chunks = file_info_.chunkids.size();
+        // check that this is the last chunk in the file
+        if (chunk == file_info_.chunkids[num_chunks - 1])
+        {
+            file_info_.size = ((num_chunks - 1) * constants::bytes_per_chunk) +
+                              cwn.new_size();
+        }
+    }
+
+    return true;
 }
 
-void sadmd::
-create_file(std::string const& filename)
+void
+sadmd::create_file(std::string const &filename)
 {
-	load_file(filename, {});
+    load_file(filename, {});
 }
 
-void sadmd::
-load_file(std::string const& filename, std::string const& existing_chunks)
+void
+sadmd::load_file(std::string const &filename,
+                 std::string const &existing_chunks)
 {
-	if (files_.count(filename))
-	{
-		std::cerr << "Error: attempt to load " 
-				  << filename 
-				  << ": file already exists\n";
-		return;
-	}
-	files_.emplace(filename, file_info{});
-	auto& file_chunkids  = files_[filename].chunkids;
-	file_chunkids.deserialize(existing_chunks);
-	reintroduce_chunks_to_network(file_chunkids);
+    if (files_.count(filename))
+    {
+        std::cerr << "Error: attempt to load " << filename
+                  << ": file already exists\n";
+        return;
+    }
+    files_.emplace(filename, file_info{});
+    auto &file_chunkids = files_[filename].chunkids;
+    file_chunkids.deserialize(existing_chunks);
+    reintroduce_chunks_to_network(file_chunkids);
 }
 
-void sadmd::
-db_command(std::string const& stmt) const
+void
+sadmd::db_command(std::string const &stmt) const
 {
-	if (sqlite3_exec(files_db_, stmt.c_str(), nullptr, nullptr, nullptr) != 0)
-	{
-		std::cerr << "Error running {" << stmt << "}: ";
-		std::cerr << sqlite3_errmsg(files_db_) << '\n';
-		std::exit(1);
-	}
+    if (sqlite3_exec(files_db_, stmt.c_str(), nullptr, nullptr, nullptr) != 0)
+    {
+        std::cerr << "Error running {" << stmt << "}: ";
+        std::cerr << sqlite3_errmsg(files_db_) << '\n';
+        std::exit(1);
+    }
 }
 
-bool sadmd::
-db_contains(std::string const& filename) const
+bool
+sadmd::db_contains(std::string const &filename) const
 {
-	auto contains = false;
-	sqlite3_stmt* stmt;
-	auto cmd = std::string{"SELECT * FROM files WHERE filename='" + filename +
-		"';"};
+    auto          contains = false;
+    sqlite3_stmt *stmt;
+    auto          cmd =
+        std::string{"SELECT * FROM files WHERE filename='" + filename + "';"};
 
-	if (sqlite3_prepare_v2(files_db_, cmd.c_str(), -1, &stmt, nullptr) != 0)
-	{
-		std::cerr << sqlite3_errmsg(files_db_) << '\n';
-		std::exit(1);
-	}
-	contains = (sqlite3_step(stmt) == SQLITE_ROW);
-	sqlite3_finalize(stmt);
+    if (sqlite3_prepare_v2(files_db_, cmd.c_str(), -1, &stmt, nullptr) != 0)
+    {
+        std::cerr << sqlite3_errmsg(files_db_) << '\n';
+        std::exit(1);
+    }
+    contains = (sqlite3_step(stmt) == SQLITE_ROW);
+    sqlite3_finalize(stmt);
 
-	return contains;
+    return contains;
 }
 
-void sadmd::
-load_files()
+void
+sadmd::load_files()
 {
-	sqlite3_stmt* stmt;
-	if (sqlite3_prepare_v2(files_db_, "SELECT * FROM files;", -1, &stmt, nullptr) != 0)
-	{
-		std::cerr << sqlite3_errmsg(files_db_) << '\n';
-		std::exit(1);
-	}
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(files_db_, "SELECT * FROM files;", -1, &stmt,
+                           nullptr) != 0)
+    {
+        std::cerr << sqlite3_errmsg(files_db_) << '\n';
+        std::exit(1);
+    }
 
-	while (sqlite3_step(stmt) == SQLITE_ROW)
-	{
-		auto filename = std::string{reinterpret_cast<const char*>(
-			sqlite3_column_text(stmt, constants::filename_col))};
-		auto cids = std::string{reinterpret_cast<const char*>(
-			sqlite3_column_text(stmt, constants::chunkid_str_col))};
-		load_file(filename, cids);
-	}
-	sqlite3_finalize(stmt);
+    while (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        auto filename = std::string{reinterpret_cast<const char *>(
+            sqlite3_column_text(stmt, constants::filename_col))};
+        auto cids     = std::string{reinterpret_cast<const char *>(
+            sqlite3_column_text(stmt, constants::chunkid_str_col))};
+        load_file(filename, cids);
+    }
+    sqlite3_finalize(stmt);
 }
 
-void sadmd::
-save_files() const noexcept
+void
+sadmd::save_files() const noexcept
 {
-	for (auto file : files_)
-	{
-		auto sql_command = std::string{};
-		auto filename = std::string{file.first};
-		auto chunkids = file.second.chunkids.serialize();
+    for (auto file : files_)
+    {
+        auto sql_command = std::string{};
+        auto filename    = std::string{file.first};
+        auto chunkids    = file.second.chunkids.serialize();
 
-		if(db_contains(file.first))
-		{
-			sql_command += "UPDATE files SET chunkids='";
-			sql_command += chunkids + "' WHERE filename='" + filename + "';";
-		}
-		else
-		{
-			sql_command += "INSERT INTO files VALUES('";
-			sql_command += filename + "', '" +  chunkids + "');";
-		}
-		db_command(sql_command);
-	}
-}
-
-bool sadmd::
-add_server_to_network(serverid uuid, comm::service service, 
-					  uint64_t max_chunks, uint64_t chunk_count)
-{
-	if (chunk_server_metadata_.count(uuid))
-	{
-		std::cerr << "Error: attempt to add server "
-			<< to_string(uuid)
-			<< " which is already on the network\n";
-		return false;
-	}
-	chunk_server_metadata_.emplace(
-		uuid,
-		chunk_server_info{
-			service,
-			max_chunks,
-			chunk_count,
-			time::from_now(time::server_ttl)
-		}
-	);
-	return true;
-}
-	
-void sadmd::
-remove_server_from_network(serverid id) noexcept
-{
-	chunk_server_metadata_.erase(id);
+        if (db_contains(file.first))
+        {
+            sql_command += "UPDATE files SET chunkids='";
+            sql_command += chunkids + "' WHERE filename='" + filename + "';";
+        }
+        else
+        {
+            sql_command += "INSERT INTO files VALUES('";
+            sql_command += filename + "', '" + chunkids + "');";
+        }
+        db_command(sql_command);
+    }
 }
 
-void sadmd::
-register_server_heartbeat(serverid id) noexcept
+bool
+sadmd::add_server_to_network(serverid uuid, comm::service service,
+                             uint64_t max_chunks, uint64_t chunk_count)
 {
-	if (!chunk_server_metadata_.count(id))
-	{
-		std::cerr << "Error: received heartbeat from server "
-			<< to_string(id)
-			<< " which is not on the network\n";
-		return;
-	}
-	// use the default value
-	chunk_server_metadata_.at(id).valid_until = time::from_now(time::server_ttl);
+    if (chunk_server_metadata_.count(uuid))
+    {
+        std::cerr << "Error: attempt to add server " << to_string(uuid)
+                  << " which is already on the network\n";
+        return false;
+    }
+    chunk_server_metadata_.emplace(
+        uuid, chunk_server_info{service, max_chunks, chunk_count,
+                                time::from_now(time::server_ttl)});
+    return true;
 }
 
-bool sadmd::
-is_active(serverid id) const noexcept
+void
+sadmd::remove_server_from_network(serverid id) noexcept
 {
-	if (!chunk_server_metadata_.count(id))
-	{
-		std::cerr << "Error: query for status of server "
-			<< to_string(id)
-			<< " which is not on the network\n";
-		return false;
-	}
-	return (chunk_server_metadata_.at(id).valid_until) > time::now();
+    chunk_server_metadata_.erase(id);
 }
 
-void sadmd::
-append_chunk_to_file(std::string const& filename, chunkid new_chunkid)
+void
+sadmd::register_server_heartbeat(serverid id) noexcept
 {
-	if (!files_.count(filename))
-	{
-		std::cerr << "Error: cannot append chunk to file "
-				  << filename
-				  << ": file does not exist\n";
-		return;
-	}
-	files_[filename].chunkids.add_chunk(new_chunkid);
-	chunk_metadata_.emplace(new_chunkid, chunk_info{});
+    if (!chunk_server_metadata_.count(id))
+    {
+        std::cerr << "Error: received heartbeat from server " << to_string(id)
+                  << " which is not on the network\n";
+        return;
+    }
+    // use the default value
+    chunk_server_metadata_.at(id).valid_until =
+        time::from_now(time::server_ttl);
 }
 
-void sadmd::
-reintroduce_chunks_to_network(util::file_chunks ids)
+bool
+sadmd::is_active(serverid id) const noexcept
 {
-	for (auto i = 0; i < ids.size(); i++)
-	{
-		chunk_metadata_.emplace(ids[i], chunk_info{});
-	}
+    if (!chunk_server_metadata_.count(id))
+    {
+        std::cerr << "Error: query for status of server " << to_string(id)
+                  << " which is not on the network\n";
+        return false;
+    }
+    return (chunk_server_metadata_.at(id).valid_until) > time::now();
 }
 
-bool sadmd::
-add_chunk_to_server(chunkid cid, version v, serverid sid)
+void
+sadmd::append_chunk_to_file(std::string const &filename, chunkid new_chunkid)
 {
-	auto& info = chunk_metadata_[cid];
-	// add server to chunk's locations
-	info.locations.emplace(sid, v);
-	// make sure latest version is correct
-	info.latest_version = std::max<version>(info.latest_version, v);
-	return true;
+    if (!files_.count(filename))
+    {
+        std::cerr << "Error: cannot append chunk to file " << filename
+                  << ": file does not exist\n";
+        return;
+    }
+    files_[filename].chunkids.add_chunk(new_chunkid);
+    chunk_metadata_.emplace(new_chunkid, chunk_info{});
 }
-  
-} // sadfs namespace
+
+void
+sadmd::reintroduce_chunks_to_network(util::file_chunks ids)
+{
+    for (auto i = 0; i < ids.size(); i++)
+    {
+        chunk_metadata_.emplace(ids[i], chunk_info{});
+    }
+}
+
+bool
+sadmd::add_chunk_to_server(chunkid cid, version v, serverid sid)
+{
+    auto &info = chunk_metadata_[cid];
+    // add server to chunk's locations
+    info.locations.emplace(sid, v);
+    // make sure latest version is correct
+    info.latest_version = std::max<version>(info.latest_version, v);
+    return true;
+}
+
+} // namespace sadfs


### PR DESCRIPTION
- sadmd is untested, but there should be no surprises based on the following results
- dummy-sadmd is able to read and print dummy-sadcd's
  host id
- dummy-sadmd is able to read and print the real sadcd's
  host id
- lots of changes from clang-format
**NOTE:** important files are
- msgs/master/message_processor.hpp
- serializer_impl.hpp
- sadcd.hpp & sadcd.cpp
- sadmd.hpp & sadmd.cpp
- heart.hpp & heart.cpp