### PR TITLE
Release lock

### DIFF
--- a/example/send-req.cpp
+++ b/example/send-req.cpp
@@ -197,7 +197,7 @@ main(int argc, char** argv)
         request_chunk("/mnt/a/file.dat", 0, 'r');
         request_chunk("/mnt/a/file.dat", 7, 'w');
         request_chunk("/mnt/a/file.dat", 0, 'w');
-		release_lock("/mnt/a/file.dat");
+        release_lock("/mnt/a/file.dat");
         request_chunk("/mnt/a/file.dat", 2, 'w');
         request_chunk("/mnt/a/file.da", 0, 'r');
     }

--- a/example/send-req.cpp
+++ b/example/send-req.cpp
@@ -163,6 +163,18 @@ file_exists(std::string filename)
     return response.ok();
 }
 
+void
+release_lock(std::string filename)
+{
+    auto rl = msgs::master::release_lock{filename};
+
+    auto ch = establish_conn();
+
+    // send chunk_write_notification
+    msgs::master::serializer{}.serialize(rl, ch);
+    ch.flush();
+}
+
 int
 main(int argc, char** argv)
 {
@@ -185,6 +197,7 @@ main(int argc, char** argv)
         request_chunk("/mnt/a/file.dat", 0, 'r');
         request_chunk("/mnt/a/file.dat", 7, 'w');
         request_chunk("/mnt/a/file.dat", 0, 'w');
+		release_lock("/mnt/a/file.dat");
         request_chunk("/mnt/a/file.dat", 2, 'w');
         request_chunk("/mnt/a/file.da", 0, 'r');
     }

--- a/include/sadfs/msgs/master/message_processor.hpp
+++ b/include/sadfs/msgs/master/message_processor.hpp
@@ -124,6 +124,19 @@ processor::process_next(channel const& ch, Handler& h)
             res = false;
         }
         break;
+    case container_type::MsgCase::kReleaseLock:
+        if constexpr (is_detected_v<can_handle, Handler, release_lock>)
+        {
+            auto msg = release_lock{};
+            res      = res && extract_header() && extract(msg, container_) &&
+                  h.handle(msg, header, ch);
+        }
+        else
+        {
+            // cannot handle this message
+            res = false;
+        }
+        break;
     case container_type::MsgCase::MSG_NOT_SET:
         // nothing to handle
         res = false;

--- a/include/sadfs/msgs/master/messages.hpp
+++ b/include/sadfs/msgs/master/messages.hpp
@@ -29,7 +29,7 @@ enum class msg_type
     chunk_location_request,
     chunk_server_heartbeat,
     join_network_request,
-    release_lock
+    release_lock,
 };
 
 class file_metadata_request

--- a/include/sadfs/msgs/master/messages.hpp
+++ b/include/sadfs/msgs/master/messages.hpp
@@ -28,7 +28,8 @@ enum class msg_type
     chunk_write_notification,
     chunk_location_request,
     chunk_server_heartbeat,
-    join_network_request
+    join_network_request,
+    release_lock
 };
 
 class file_metadata_request
@@ -156,6 +157,24 @@ private:
 bool embed(join_network_request const&, message_container&);
 bool extract(join_network_request&, message_container const&);
 
+class release_lock	
+{	
+public:	
+    release_lock() = default;	
+    release_lock(std::string const &filename);	
+
+    std::string const &filename() const;	
+
+    inline static msg_type type{msg_type::release_lock};	
+
+private:	
+    proto::master::release_lock protobuf_{};	
+
+    // provide embed/extract functions access to private members	
+    friend bool embed(release_lock const &, message_container &);	
+    friend bool extract(release_lock &, message_container const &);	
+};
+
 // ==================================================================
 //                     inline function definitions
 // ==================================================================
@@ -242,6 +261,12 @@ inline uint64_t
 join_network_request::chunk_count() const
 {
     return protobuf_.chunk_count();
+}
+
+inline std::string const &	
+release_lock::filename() const	
+{	
+    return protobuf_.filename();	
 }
 
 } // namespace master

--- a/include/sadfs/msgs/master/messages.hpp
+++ b/include/sadfs/msgs/master/messages.hpp
@@ -157,22 +157,22 @@ private:
 bool embed(join_network_request const&, message_container&);
 bool extract(join_network_request&, message_container const&);
 
-class release_lock	
-{	
-public:	
-    release_lock() = default;	
-    release_lock(std::string const &filename);	
+class release_lock
+{
+public:
+    release_lock() = default;
+    release_lock(std::string const& filename);
 
-    std::string const &filename() const;	
+    std::string const& filename() const;
 
-    inline static msg_type type{msg_type::release_lock};	
+    inline static msg_type type{msg_type::release_lock};
 
-private:	
-    proto::master::release_lock protobuf_{};	
+private:
+    proto::master::release_lock protobuf_{};
 
-    // provide embed/extract functions access to private members	
-    friend bool embed(release_lock const &, message_container &);	
-    friend bool extract(release_lock &, message_container const &);	
+    // provide embed/extract functions access to private members
+    friend bool embed(release_lock const&, message_container&);
+    friend bool extract(release_lock&, message_container const&);
 };
 
 // ==================================================================
@@ -263,10 +263,10 @@ join_network_request::chunk_count() const
     return protobuf_.chunk_count();
 }
 
-inline std::string const &	
-release_lock::filename() const	
-{	
-    return protobuf_.filename();	
+inline std::string const&
+release_lock::filename() const
+{
+    return protobuf_.filename();
 }
 
 } // namespace master

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -82,6 +82,9 @@ public:
     bool handle(msgs::master::file_metadata_request const&,
                 msgs::message_header const&, msgs::channel const&);
 
+    // handles a release_lock
+    bool handle(msgs::master::release_lock const&,
+                msgs::message_header const&, msgs::channel const&);
 private:
     // takes ownership of a channel and serves the request on it
     void serve_requests(msgs::channel);

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -83,8 +83,9 @@ public:
                 msgs::message_header const&, msgs::channel const&);
 
     // handles a release_lock
-    bool handle(msgs::master::release_lock const&,
-                msgs::message_header const&, msgs::channel const&);
+    bool handle(msgs::master::release_lock const&, msgs::message_header const&,
+                msgs::channel const&);
+
 private:
     // takes ownership of a channel and serves the request on it
     void serve_requests(msgs::channel);

--- a/src/msgs/master/messages.cpp
+++ b/src/msgs/master/messages.cpp
@@ -26,6 +26,7 @@ auto const msg_type_lookup = msg_type_map{
     {MsgCase::kChunkLocationReq, msg_type::chunk_location_request},
     {MsgCase::kChunkServerHeartbeat, msg_type::chunk_server_heartbeat},
     {MsgCase::kJoinNetworkReq, msg_type::join_network_request},
+    {MsgCase::kReleaseLock, msg_type::release_lock},
 };
 
 } // unnamed namespace
@@ -265,6 +266,42 @@ extract(join_network_request& req, message_container const& container)
 
     // read join_network_request from message_container
     req.protobuf_ = container.join_network_req();
+    return true;
+}
+
+/* ========================================================
+ *                       release_lock
+ * ========================================================
+ */
+release_lock::release_lock(std::string const& filename)
+{
+    protobuf_.set_filename(filename);
+}
+
+// embeds a control message into a container that is
+// (typically) sent over the wire
+bool
+embed(release_lock const& req, message_container& container)
+{
+    // should this be in a try-catch block?
+    // msg.mutable_release_lock() can throw if heap allocation fails
+    *container.mutable_release_lock() = req.protobuf_;
+    return true;
+}
+
+// extracts a control message from a container that is
+// (typically) received over the wire
+bool
+extract(release_lock& req, message_container const& container)
+{
+    if (msg_type_lookup.at(container.msg_case()) != release_lock::type)
+    {
+        // cannot extract a msg that doesn't exist
+        return false;
+    }
+
+    // read release_lock from message_container
+    req.protobuf_ = container.release_lock();
     return true;
 }
 } // namespace master

--- a/src/proto/master.proto
+++ b/src/proto/master.proto
@@ -42,10 +42,16 @@ message file_metadata_request {
 	string filename	= 1;
 }
 
+// notification of release of write lock
+message release_lock {
+	string filename	= 1;
+}
+
 // container for control messages
 message message_container {
 	sadfs.proto.header  header = 1;
 	oneof               msg {
+		release_lock release_lock = 5;
 		chunk_location_request chunk_location_req     = 6;
 		chunk_server_heartbeat chunk_server_heartbeat = 7;
 	    	chunk_write_notification chunk_write_notify   = 8;

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -2,6 +2,7 @@
 
 // sadfs-specific includes
 #include <sadfs/comm/inet.hpp>
+#include <sadfs/logger.hpp>
 #include <sadfs/msgs/channel.hpp>
 #include <sadfs/msgs/client/serializer.hpp>
 #include <sadfs/msgs/master/message_processor.hpp>
@@ -336,6 +337,20 @@ sadmd::handle(msgs::master::chunk_write_notification const& cwn,
         }
     }
 
+    return true;
+}
+
+bool
+sadmd::handle(msgs::master::release_lock const& rl,
+              msgs::message_header const&, msgs::channel const& ch)
+{
+    auto it = files_.find(rl.filename());
+    if (it != files_.end())
+    {
+        logger::debug("unlocked file"sv);
+        it->second.locked_until = time::now();
+    }
+    // TODO: send ack
     return true;
 }
 


### PR DESCRIPTION
This is the simplest possible working version of a release_lock message and handler. The master currently has no mechanism to verify that the sender holds the lock, so it simply trusts any incoming message is from the right client and unlocks the file. It also doesn't send an ack yet.