### PR TITLE
implemented chunk append request forwarding

### DIFF
--- a/example/sadcd-tests.cpp
+++ b/example/sadcd-tests.cpp
@@ -125,7 +125,10 @@ test_append(std::string id, uint32_t length, std::string data, bool expected)
     total++;
     auto cid = uuid::from_string(id);
     auto req =
-        msgs::chunk::append_request{cid, length, {}, "irrelevant_name.dat"};
+        msgs::chunk::append_request{cid,
+                                    length,
+                                    {{"127.0.0.1", 6669}, {"127.0.0.1", 6670}},
+                                    "irrelevant_name.dat"};
     auto sock = service.connect();
     if (!sock.valid())
     {

--- a/include/sadfs/constants.hpp
+++ b/include/sadfs/constants.hpp
@@ -6,9 +6,9 @@ namespace sadfs
 namespace constants
 {
 
-constexpr auto bytes_per_chunk = 64 * 1024 * 1024; // 64MB
+constexpr auto chunk_capacity = 64 * 1024 * 1024U; // 64MB
 
-} // constants namespace
-} // sadfs namespace
+} // namespace constants
+} // namespace sadfs
 
 #endif // SADFS_CONSTANTS_HPP

--- a/include/sadfs/msgs/chunk/message_processor.hpp
+++ b/include/sadfs/msgs/chunk/message_processor.hpp
@@ -74,6 +74,20 @@ processor::process_next(msgs::channel const& ch, Handler& h)
             res = false;
         }
         break;
+    case container_type::kAppendForwardReq:
+        if constexpr (is_detected_v<can_handle, Handler,
+                                    append_forward_request>)
+        {
+            auto msg = append_forward_request{};
+            res      = res && extract_header() && extract(msg, container_) &&
+                  h.handle(msg, header, ch);
+        }
+        else
+        {
+            // cannot handle this message
+            res = false;
+        }
+        break;
     case container_type::MsgCase::MSG_NOT_SET:
         // nothing to handle
         res = false;

--- a/include/sadfs/msgs/chunk/messages.hpp
+++ b/include/sadfs/msgs/chunk/messages.hpp
@@ -27,6 +27,7 @@ enum class msg_type
     read_request,
     stream,
     append_request,
+    append_forward_request,
 };
 
 // chunk::acknowledgement
@@ -82,6 +83,31 @@ private:
     friend bool extract(append_request&, message_container const&);
 };
 
+class append_forward_request
+{
+public:
+    // constructors
+    append_forward_request() = default;
+    append_forward_request(chunkid chunk_id, uint32_t length,
+                           std::vector<comm::service> const& replicas,
+                           std::string const&                filename);
+
+    chunkid            chunk_id() const;
+    uint32_t           length() const;
+    comm::service      replicas(int const) const;
+    int                replicas_size() const;
+    std::string const& filename() const;
+
+    inline static msg_type type{msg_type::append_forward_request};
+
+private:
+    proto::chunk::append_forward_request protobuf_{};
+
+    // provide embed/extract functions access to private members
+    friend bool embed(append_forward_request const&, message_container&);
+    friend bool extract(append_forward_request&, message_container const&);
+};
+
 // ==================================================================
 //                      inline function definitions
 // ==================================================================
@@ -134,6 +160,39 @@ append_request::replicas(int const i) const
 
 inline std::string const&
 append_request::filename() const
+{
+    return protobuf_.filename();
+}
+
+inline chunkid
+append_forward_request::chunk_id() const
+{
+    auto id = chunkid{};
+    id.deserialize(protobuf_.chunk_id().data());
+    return id;
+}
+
+inline uint32_t
+append_forward_request::length() const
+{
+    return protobuf_.length();
+}
+
+inline int
+append_forward_request::replicas_size() const
+{
+    return protobuf_.replicas_size();
+}
+
+inline comm::service
+append_forward_request::replicas(int const i) const
+{
+    auto replica = protobuf_.replicas(i);
+    return {replica.ip().c_str(), replica.port()};
+}
+
+inline std::string const&
+append_forward_request::filename() const
 {
     return protobuf_.filename();
 }

--- a/include/sadfs/sadcd/io.hpp
+++ b/include/sadfs/sadcd/io.hpp
@@ -35,8 +35,25 @@ struct write_spec
     std::string_view   data;
 };
 
+struct forwarding_spec
+{
+    chunkid const&             id;
+    uint32_t                   length;
+    std::string const&         filename;
+    std::string_view           data;
+    std::vector<comm::service> forwarding_list;
+};
+
 bool read(read_spec const);
-bool append(write_spec const, comm::service const&, serverid const&);
+bool append(write_spec, comm::service const&, serverid const&);
+
+// forwards a write/append request to downstream chunk servers
+void forward(forwarding_spec const& spec, serverid const& sid);
+
+auto flush = [](auto const& ch) {
+    ch.flush();
+    return true;
+};
 
 } // namespace io
 } // namespace sadfs

--- a/include/sadfs/sadcd/sadcd.hpp
+++ b/include/sadfs/sadcd/sadcd.hpp
@@ -56,7 +56,8 @@ class request_handler
     comm::service const&                  master_;
     serverid const                        serverid_;
 
-    bool ack_client(bool, msgs::channel const&);
+    template <typename Request, typename Ack>
+    bool handle(Request const&, Ack, msgs::channel const&);
 
 public:
     request_handler(comm::service const& master, serverid id);
@@ -65,6 +66,8 @@ public:
                 msgs::channel const&);
     bool handle(msgs::chunk::append_request const&,
                 msgs::message_header const&, msgs::channel const&);
+    bool handle(msgs::chunk::append_forward_request const& req,
+                msgs::message_header const&, msgs::channel const& ch);
 };
 
 } // namespace sadfs

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -65,10 +65,8 @@ public:
                 msgs::message_header const&, msgs::channel const&);
 
     // handles a chunk_server_hearbeat
-    /* TODO
     bool handle(msgs::master::chunk_server_heartbeat const&,
-                msgs::message_header const &, msgs::channel const &);
-    */
+                msgs::message_header const&, msgs::channel const&);
 
     // handles a join_network_request and responds to channel it came in on
     bool handle(msgs::master::join_network_request const&,

--- a/src/msgs/chunk/messages.cpp
+++ b/src/msgs/chunk/messages.cpp
@@ -22,6 +22,7 @@ auto const msg_type_lookup = msg_type_map{
     {MsgCase::MSG_NOT_SET, msg_type::unknown},
     {MsgCase::kAck, msg_type::acknowledgement},
     {MsgCase::kAppendReq, msg_type::append_request},
+    {MsgCase::kAppendForwardReq, msg_type::append_forward_request},
     {MsgCase::kReadReq, msg_type::read_request},
     {MsgCase::kStream, msg_type::stream},
 };
@@ -109,6 +110,54 @@ extract(append_request& req, message_container const& container)
 
     // copy the request from the container
     req.protobuf_ = container.append_req();
+    return true;
+}
+
+/* ========================================================
+ *                       append_forward_request
+ * ========================================================
+ */
+append_forward_request::append_forward_request(
+    chunkid chunk_id, uint32_t length,
+    std::vector<comm::service> const& replicas, std::string const& filename)
+{
+    chunk_id.serialize(std::back_inserter(*protobuf_.mutable_chunk_id()));
+    protobuf_.set_length(length);
+    for (auto const& replica : replicas)
+    {
+        auto r = protobuf_.add_replicas();
+        r->set_ip(to_string(replica.ip()));
+        r->set_port(to_int(replica.port()));
+    }
+    protobuf_.set_filename(filename);
+}
+
+// embeds a control message into a container that is
+// (typically) sent over the wire
+bool
+embed(append_forward_request const& req, message_container& container)
+{
+    // should this be in a try-catch block?
+    // container.mutable_append_forward_req() can throw if heap allocation
+    // fails
+    *container.mutable_append_forward_req() = req.protobuf_;
+    return true;
+}
+
+// extracts a control message from a container that is
+// (typically) received over the wire
+bool
+extract(append_forward_request& req, message_container const& container)
+{
+    if (msg_type_lookup.at(container.msg_case()) !=
+        append_forward_request::type)
+    {
+        // cannot extract a msg that doesn't exist
+        return false;
+    }
+
+    // copy the request from the container
+    req.protobuf_ = container.append_forward_req();
     return true;
 }
 

--- a/src/proto/chunk.proto
+++ b/src/proto/chunk.proto
@@ -17,13 +17,21 @@ message append_request {
 	string                       filename = 5;
 }
 
+message append_forward_request {
+	bytes                        chunk_id = 1;
+	uint32                       length   = 3;
+	repeated sadfs.proto.service replicas = 4;
+	string                       filename = 5;
+}
+
 // container for control messages
 message message_container {
 	sadfs.proto.header  header = 1;
 	oneof               msg {
-		sadfs.proto.acknowledgement ack        = 6;
-		read_request                read_req   = 7;
-		append_request              append_req = 8;
-		sadfs.proto.stream          stream     = 9;
+		sadfs.proto.acknowledgement ack                = 6;
+		read_request                read_req           = 7;
+		append_request              append_req         = 8;
+		append_forward_request      append_forward_req = 9;
+		sadfs.proto.stream          stream             = 10;
 	}
 }

--- a/src/proto/internal.proto
+++ b/src/proto/internal.proto
@@ -11,5 +11,6 @@ message chunk_metadata {
 		uint32 version = 1;
 		uint32 size    = 2;
 	}
-	repeated version_info versions = 1;
+	version_info          current   = 1;
+	repeated version_info snapshots = 2;
 }

--- a/src/sadcd/io.cpp
+++ b/src/sadcd/io.cpp
@@ -3,6 +3,8 @@
 #include <sadfs/logger.hpp>
 #include <sadfs/msgs/channel.hpp>
 #include <sadfs/msgs/chunk/deserializer.hpp>
+#include <sadfs/msgs/chunk/messages.hpp>
+#include <sadfs/msgs/chunk/serializer.hpp>
 #include <sadfs/msgs/master/messages.hpp>
 #include <sadfs/msgs/master/serializer.hpp>
 #include <sadfs/sadcd/io.hpp>
@@ -47,7 +49,7 @@ filename(chunkid const& id, std::optional<uint32_t> version)
 }
 
 bool
-write_to_disk(write_spec const spec)
+write_to_disk(write_spec const& spec)
 {
     auto const path = filename(spec.id, {});
     if (spec.ver == 0 && !mkdir(path))
@@ -74,7 +76,7 @@ write_to_disk(write_spec const spec)
 }
 
 bool
-notify_master(write_spec const spec, comm::service const& master,
+notify_master(write_spec const& spec, comm::service const& master,
               serverid const& sid)
 {
     auto sock = master.connect();
@@ -92,6 +94,25 @@ notify_master(write_spec const spec, comm::service const& master,
     return msgs::master::serializer{{sid}}.serialize(cwn, ch);
 }
 
+bool
+forward(forwarding_spec const& spec, msgs::channel const& ch, size_t start)
+{
+    auto serializer   = msgs::chunk::serializer{};
+    auto deserializer = msgs::chunk::deserializer{};
+    auto ack          = msgs::chunk::acknowledgement{};
+    auto req          = msgs::chunk::append_forward_request{
+        spec.id,
+        spec.length,
+        {spec.forwarding_list.begin() + start, spec.forwarding_list.end()},
+        spec.filename};
+    auto stream = msgs::chunk::stream{std::string{spec.data}};
+
+    return serializer.serialize(req, ch) && flush(ch) &&
+           deserializer.deserialize(ack, ch).first && ack.ok() &&
+           serializer.serialize(stream, ch) && flush(ch) &&
+           deserializer.deserialize(ack, ch).first && ack.ok();
+}
+
 } // unnamed namespace
 
 bool
@@ -106,7 +127,43 @@ append(write_spec const spec, comm::service const& master, serverid const& sid)
     {
         return false;
     }
+
     return true;
+}
+
+void
+forward(forwarding_spec const& spec, serverid const& sid)
+{
+    // stream data to the first server in the forwarding list
+    auto [sock, start] = [&spec]() {
+        for (auto iter = spec.forwarding_list.begin();
+             iter != spec.forwarding_list.end(); iter++)
+        {
+            auto sock = iter->connect();
+            if (sock.valid())
+            {
+                size_t connected = iter - spec.forwarding_list.begin();
+                // return socket and index of the next server in the list
+                // so that the server we connected to can then forward
+                // the write/append request
+                return std::make_pair(std::move(sock), connected + 1);
+            }
+            logger::error("data could not be forwarded to " +
+                          to_string(iter->ip()) + ":" +
+                          std::to_string(to_int(iter->port())));
+        }
+        return std::make_pair(comm::socket{}, spec.forwarding_list.size());
+    }();
+    if (!sock.valid())
+    {
+        return;
+    }
+
+    if (!forward(spec, std::move(sock), start))
+    {
+        logger::error("data could not be forwarded"sv);
+    }
+    return;
 }
 
 } // namespace io

--- a/src/sadfsd/sadfilesys.cpp
+++ b/src/sadfsd/sadfilesys.cpp
@@ -13,8 +13,8 @@
 #include <sadfs/sadfsd/sadfilesys.hpp>
 
 // external includes
-#include <cerrno>	// error codes
-#include <cstring> 	// strerror() and memcpy()
+#include <cerrno>  // error codes
+#include <cstring> // strerror() and memcpy()
 
 namespace sadfs
 {
@@ -63,20 +63,20 @@ sadfilesys::getattr(char const* path, struct stat* stbuf)
     auto result{0};
 
     if ((strlen(path) >= 2 && path[0] == '/' && path[1] == '.') ||
-    	strcmp(path, "/autorun.inf") == 0)
+        strcmp(path, "/autorun.inf") == 0)
     {
-        result = -ENOENT; 	// No such file or directory
+        result = -ENOENT; // No such file or directory
         logger::debug("gettattr() failed with error " +
                       std::string(strerror(-result)));
         return result;
     }
-    
+
     // base directory where filesystem is mounted
     if (strcmp(path, "/") == 0)
     {
         logger::debug("path identified as base directory"sv);
         stbuf->st_mode = S_IFDIR | 0755;
-	stbuf->st_size = 0;
+        stbuf->st_size = 0;
         return result;
     }
 
@@ -88,7 +88,7 @@ sadfilesys::getattr(char const* path, struct stat* stbuf)
     auto sock         = master_service_.connect();
     if (!sock.valid())
     {
-        result = -ENETUNREACH;	// Network is unreachable
+        result = -ENETUNREACH; // Network is unreachable
         logger::debug("gettattr() failed with error " +
                       std::string(strerror(-result)));
         return result;
@@ -103,19 +103,18 @@ sadfilesys::getattr(char const* path, struct stat* stbuf)
     if (!(serializer.serialize(request, ch) && flush(ch) &&
           deserializer.deserialize(response, ch).first))
     {
-        result = -EPROTONOSUPPORT;	// Protocol not supported
+        result = -EPROTONOSUPPORT; // Protocol not supported
         logger::debug("gettattr() failed with error " +
                       std::string(strerror(-result)));
         return result;
     }
     if (!response.ok())
     {
-        result = -ENOENT; 	// No such file or directory
+        result = -ENOENT; // No such file or directory
         logger::debug("gettattr() failed with error " +
                       std::string(strerror(-result)));
         return result;
     }
-
 
     logger::debug("path identified as valid filename"sv);
 
@@ -144,23 +143,20 @@ sadfilesys::read(char const* path, char* buf, size_t size, off_t offset,
                  fuse_file_info* fi)
 {
     logger::debug("read() called at " + std::string(path) + " to read " +
-    	          std::to_string(size) + " bytes at offset " +
-		  std::to_string(offset));
+                  std::to_string(size) + " bytes at offset " +
+                  std::to_string(offset));
 
     auto result{0};
-    auto location_request = msgs::master::chunk_location_request
-    {
-    	msgs::io_type::read,
-	std::string{path},
-	static_cast<uint32_t> (offset / constants::bytes_per_chunk)
-    };
-    auto location_response	= msgs::client::chunk_location_response{};
-    auto master_serializer 	= msgs::master::serializer{};
-    auto client_deserializer	= msgs::client::deserializer{};
-    auto master_sock		= master_service_.connect();
+    auto location_request = msgs::master::chunk_location_request{
+        msgs::io_type::read, std::string{path},
+        static_cast<uint32_t>(offset / constants::chunk_capacity)};
+    auto location_response   = msgs::client::chunk_location_response{};
+    auto master_serializer   = msgs::master::serializer{};
+    auto client_deserializer = msgs::client::deserializer{};
+    auto master_sock         = master_service_.connect();
     if (!master_sock.valid())
     {
-        result = -ENETUNREACH;	// Network is unreachable
+        result = -ENETUNREACH; // Network is unreachable
         logger::debug("read() failed with error " +
                       std::string(strerror(-result)));
         return result;
@@ -168,22 +164,22 @@ sadfilesys::read(char const* path, char* buf, size_t size, off_t offset,
     auto master_ch = msgs::channel{std::move(master_sock)};
 
     auto flush = [](auto const& ch) {
-    	ch.flush();
-	return true;
+        ch.flush();
+        return true;
     };
 
     if (!(master_serializer.serialize(location_request, master_ch) &&
-        flush(master_ch) &&
-	client_deserializer.deserialize(location_response, master_ch).first))
+          flush(master_ch) &&
+          client_deserializer.deserialize(location_response, master_ch).first))
     {
-        result = -EPROTONOSUPPORT;	// Communication error on send
+        result = -EPROTONOSUPPORT; // Communication error on send
         logger::debug("read() failed to get chunk location " +
                       std::string(strerror(-result)));
         return result;
     }
     if (!location_response.ok())
     {
-        result = -EBADMSG;	// Bad message
+        result = -EBADMSG; // Bad message
         logger::debug("read() chunk location not found " +
                       std::string(strerror(-result)));
         return result;
@@ -191,95 +187,86 @@ sadfilesys::read(char const* path, char* buf, size_t size, off_t offset,
     if (size == 0) // Not sure if we ever get such a request
     {
         logger::debug("read() of size 0 requested"sv);
-    	return result;
+        return result;
     }
     if (location_response.locations_size() == 0)
     {
-    	result =  -EPROTO;	// Protocol error
+        result = -EPROTO; // Protocol error
         logger::debug("read() empty chunk location returned " +
                       std::string(strerror(-result)));
         return result;
     }
-    
-    
-    auto file_size	= location_response.file_size();
+
+    auto file_size = location_response.file_size();
     logger::debug("read() got file size " + std::to_string(file_size));
     if (static_cast<uint32_t>(offset) >= file_size)
     {
-    	return result;
+        return result;
     }
 
-    auto chunk_offset	= static_cast<uint32_t>(
-    				offset % constants::bytes_per_chunk);
-    auto chunk_read_size= std::min<uint32_t>({
-					static_cast<uint32_t>(size),
-				    	constants::bytes_per_chunk -
-						chunk_offset,
-				    	file_size - 
-						static_cast<uint32_t>(offset)
-				});
-    auto chunk_request	= msgs::chunk::read_request
-    {
-	location_response.chunk_id(),
-	chunk_offset,
-	chunk_read_size
-    };
-    auto chunk_response	= msgs::client::read_response{};
+    auto chunk_offset =
+        static_cast<uint32_t>(offset % constants::chunk_capacity);
+    auto chunk_read_size = std::min<uint32_t>(
+        {static_cast<uint32_t>(size), constants::chunk_capacity - chunk_offset,
+         file_size - static_cast<uint32_t>(offset)});
+    auto chunk_request = msgs::chunk::read_request{
+        location_response.chunk_id(), chunk_offset, chunk_read_size};
+    auto chunk_response   = msgs::client::read_response{};
     auto chunk_serializer = msgs::chunk::serializer{};
 
     for (auto i = 0; i < location_response.locations_size(); ++i)
     {
-    	auto chunk_sock = location_response.service(i).connect();
-	if (!chunk_sock.valid())
-	{
-		result = -ENETUNREACH; // Network is unreachable
-		continue;
-	}
-	auto chunk_ch = msgs::channel{std::move(chunk_sock)};
+        auto chunk_sock = location_response.service(i).connect();
+        if (!chunk_sock.valid())
+        {
+            result = -ENETUNREACH; // Network is unreachable
+            continue;
+        }
+        auto chunk_ch = msgs::channel{std::move(chunk_sock)};
 
-	if (!(chunk_serializer.serialize(chunk_request, chunk_ch) &&
-	    flush(chunk_ch) &&
-	    client_deserializer.deserialize(chunk_response, chunk_ch).first))
-	{
-        	result = -EPROTONOSUPPORT;	// Protocol not supported
-		continue;
-	}
-	if (!chunk_response.ok())
-	{
-		result	= -EPROTO;	// Protocol error
-		continue;
-	}
-	auto const& chunk_data = chunk_response.data();
-	memcpy(buf, chunk_data.data(), chunk_data.size());
-     	logger::debug("read() got " + std::to_string(chunk_data.size()) +
-		      " from chunk server");
-	// result returns the number of bytes read
-	result = chunk_data.size();
-	break;
-     }
-    
-     if (result < 0)
-     {
+        if (!(chunk_serializer.serialize(chunk_request, chunk_ch) &&
+              flush(chunk_ch) &&
+              client_deserializer.deserialize(chunk_response, chunk_ch).first))
+        {
+            result = -EPROTONOSUPPORT; // Protocol not supported
+            continue;
+        }
+        if (!chunk_response.ok())
+        {
+            result = -EPROTO; // Protocol error
+            continue;
+        }
+        auto const& chunk_data = chunk_response.data();
+        memcpy(buf, chunk_data.data(), chunk_data.size());
+        logger::debug("read() got " + std::to_string(chunk_data.size()) +
+                      " from chunk server");
+        // result returns the number of bytes read
+        result = chunk_data.size();
+        break;
+    }
+
+    if (result < 0)
+    {
         logger::debug("read() failed with error " +
                       std::string(strerror(-result)));
-	return result;
-     }
+        return result;
+    }
 
-     if (result == chunk_read_size &&
-     	 offset + chunk_read_size < offset + size &&
-	 offset + chunk_read_size < file_size)
-     {
-     	auto ret = read(path, buf + chunk_read_size, size - chunk_read_size,
-		        offset + chunk_read_size, fi);
-	if (ret < 0)
-	{
-		return result;
-	}
-	return result + ret;
-     }
-     
-     logger::debug("read() finished"sv);
-     return result;
+    if (result == chunk_read_size &&
+        offset + chunk_read_size < offset + size &&
+        offset + chunk_read_size < file_size)
+    {
+        auto ret = read(path, buf + chunk_read_size, size - chunk_read_size,
+                        offset + chunk_read_size, fi);
+        if (ret < 0)
+        {
+            return result;
+        }
+        return result + ret;
+    }
+
+    logger::debug("read() finished"sv);
+    return result;
 }
 
 } // namespace sadfs

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -194,7 +194,7 @@ sadmd::handle(msgs::master::chunk_location_request const& clr,
     auto        servers     = std::vector<comm::service>{};
     auto const& filename    = clr.filename();
     auto        version_num = version{0};
-    auto	file_size   = 0u;
+    auto        file_size   = 0u;
 
     // lambda to check if a chunk number is valid for filename
     auto validate = [](auto it, auto chunk_number) {
@@ -236,7 +236,7 @@ sadmd::handle(msgs::master::chunk_location_request const& clr,
             auto& chunk = chunk_metadata_[id];
             servers     = valid_servers(chunk);
             version_num = chunk.latest_version;
-	    file_size   = it->second.size;
+            file_size   = it->second.size;
             if (servers.size() <= 0)
             {
                 std::cerr << "Error: list of server locations empty\n";
@@ -259,7 +259,7 @@ sadmd::handle(msgs::master::chunk_location_request const& clr,
             auto& chunk = chunk_metadata_[id];
             servers     = valid_servers(chunk);
             version_num = chunk.latest_version;
-	    file_size   = it->second.size;
+            file_size   = it->second.size;
             if (servers.size() <= 0)
             {
                 std::cerr << "Error: list of server locations empty\n";
@@ -345,7 +345,7 @@ sadmd::handle(msgs::master::chunk_write_notification const& cwn,
         // check that this is the last chunk in the file
         if (chunk == file_info_.chunkids[num_chunks - 1])
         {
-            file_info_.size = ((num_chunks - 1) * constants::bytes_per_chunk) +
+            file_info_.size = ((num_chunks - 1) * constants::chunk_capacity) +
                               cwn.new_size();
             logger::debug("Updated size of " + cwn.filename() + " to " +
                           std::to_string(file_info_.size));

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -369,7 +369,7 @@ sadmd::handle(msgs::master::chunk_write_notification const& cwn,
         // check that this is the last chunk in the file
         if (chunk == file_info_.chunkids[num_chunks - 1])
         {
-            file_info_.size = ((num_chunks - 1) * constants::bytes_per_chunk) +
+            file_info_.size = ((num_chunks - 1) * constants::chunk_capacity) +
                               cwn.new_size();
             logger::debug("Updated size of " + cwn.filename() + " to " +
                           std::to_string(file_info_.size));


### PR DESCRIPTION
- chunk servers now forward all append requests to 'downstream'
  servers by chaining requests: A --forward--> B --forward--> C
- if a server in the middle of a 'chain' is unreachable, servers
  'get around' the unreachable server, and keep trying to reach
  the next downstream server, and stop when they find one. It is
  then the responsibility of this server to pass the append/write
  downstream