### PR TITLE
Fuse write

### DIFF
--- a/example/dummy-sadmd.cpp
+++ b/example/dummy-sadmd.cpp
@@ -95,6 +95,14 @@ struct sadmd
 	logger::debug("received join req. " + to_string(header.host_id));
     	return true;
     }
+
+    using cfr = msgs::master::create_file_request;
+    bool handle(cfr const& req, msgs::message_header const& header,
+                msgs::channel const& ch)
+    {
+    	logger::debug("received create req. " + std::string(req.filename()));
+	return true;
+    }
 };
 
 int

--- a/example/log.sh
+++ b/example/log.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+echo "Starting logging script..."
+
+while
+do
+	echo "`date`: something important"
+	sleep 2
+	echo "`date`: something not so important"
+	sleep 2
+	echo "`date`: something went wrong..."
+	sleep 1
+	echo "`date`: and we recovered!"
+	sleep 2
+done

--- a/example/log.sh
+++ b/example/log.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+echo "Starting logging script..."
+
+while true
+do
+	echo "`date`: something important"
+	sleep 2
+	echo "`date`: something not so important"
+	sleep 2
+	echo "`date`: something went wrong..."
+	sleep 1
+	echo "`date`: and we recovered!"
+	sleep 2
+done

--- a/include/sadfs/msgs/client/messages.hpp
+++ b/include/sadfs/msgs/client/messages.hpp
@@ -24,6 +24,7 @@ enum class msg_type
     chunk_location_response,
     file_metadata_response,
     read_response,
+    read_dir_response,
 };
 
 // instantiate client::acknowledgement
@@ -72,6 +73,25 @@ private:
     friend bool embed(file_metadata_response const&, message_container&);
     friend bool extract(file_metadata_response&, message_container const&);
 };
+
+class read_dir_response
+{
+public:
+    read_dir_response() = default;
+    read_dir_response(std::vector<std::string> const& filenames);
+
+    std::string	const& filename(int) const;
+    int filenames_size() const noexcept;
+
+    inline static msg_type type{msg_type::read_dir_response};
+
+private:
+    proto::client::read_dir_response protobuf_{};
+
+    friend bool embed(read_dir_response const&, message_container&);
+    friend bool extract(read_dir_response&, message_container const&);
+};
+
 
 class read_response
 {
@@ -156,6 +176,18 @@ inline std::string const&
 read_response::data() const
 {
     return protobuf_.data();
+}
+
+inline std::string const&
+read_dir_response::filename(int i) const
+{
+    return protobuf_.filenames(i);
+}
+
+inline int
+read_dir_response::filenames_size() const noexcept
+{
+    return protobuf_.filenames_size();
 }
 
 } // namespace client

--- a/include/sadfs/msgs/master/message_processor.hpp
+++ b/include/sadfs/msgs/master/message_processor.hpp
@@ -132,6 +132,19 @@ processor::process_next(channel const& ch, Handler& h)
             res = false;
         }
         break;
+    case container_type::MsgCase::kReadDirReq:
+    	if constexpr (is_detected_v<can_handle, Handler, read_dir_request>)
+	{
+	    auto msg = read_dir_request{};
+	    res	     = res && extract_header() && extract(msg, container_) &&
+	    	  h.handle(msg, header, ch);
+	}
+        else
+        {
+            // cannot handle this message
+            res = false;
+        }
+        break;
     case container_type::MsgCase::MSG_NOT_SET:
         // nothing to handle
         res = false;

--- a/include/sadfs/msgs/master/messages.hpp
+++ b/include/sadfs/msgs/master/messages.hpp
@@ -29,6 +29,7 @@ enum class msg_type
     chunk_location_request,
     chunk_server_heartbeat,
     join_network_request,
+    read_dir_request,
     release_lock,
 };
 
@@ -164,6 +165,24 @@ private:
     friend bool extract(release_lock&, message_container const&);
 };
 
+class read_dir_request
+{
+public:
+    read_dir_request() = default;
+    read_dir_request(std::string const& dirname);
+
+    std::string const& dirname() const;
+
+    inline static msg_type type{msg_type::read_dir_request};
+
+private:
+    proto::master::read_dir_request protobuf_{};
+
+    // provide embed/extract functions access to private members
+    friend bool embed(read_dir_request const&, message_container&);
+    friend bool extract(read_dir_request&, message_container const&);
+};
+
 // ==================================================================
 //                     inline function definitions
 // ==================================================================
@@ -240,6 +259,12 @@ inline std::string const&
 release_lock::filename() const
 {
     return protobuf_.filename();
+}
+
+inline std::string const&
+read_dir_request::dirname() const
+{
+    return protobuf_.dirname();
 }
 
 } // namespace master

--- a/include/sadfs/sadfsd/sadfilesys.hpp
+++ b/include/sadfs/sadfsd/sadfilesys.hpp
@@ -34,6 +34,9 @@ private:
     // to FUSE in bootstrap()
     static sadfilesys* this_();
     
+    // create a file
+    int create(char const* path, mode_t mode, fuse_file_info* fi);
+
     // get file attributes
     int getattr(char const* path, struct stat* stbuf);
 
@@ -47,6 +50,10 @@ private:
     // read data from an open file
     int read(char const* path, char* buf, size_t size, off_t offset,
              fuse_file_info* fi);
+
+    // write to an open file
+    int write(char const* path, const char* buf, size_t size, off_t offset,
+    	      fuse_file_info* fi);
 
     fuse_operations operations_{};
     

--- a/include/sadfs/sadfsd/sadfilesys.hpp
+++ b/include/sadfs/sadfsd/sadfilesys.hpp
@@ -48,12 +48,12 @@ private:
     int open(char const* path, fuse_file_info* fi);
 
     // read data from an open file
-    int read(char const* path, char* buf, size_t size, off_t offset,
+    int read(char const* path, char* buf, uint32_t size, uint32_t offset,
              fuse_file_info* fi);
 
     // write to an open file
-    int write(char const* path, const char* buf, size_t size, off_t offset,
-    	      fuse_file_info* fi);
+    int write(char const* path, const char* buf, uint32_t size,
+    	      uint32_t offset, fuse_file_info* fi);
 
     fuse_operations operations_{};
     

--- a/include/sadfs/sadmd/sadmd.hpp
+++ b/include/sadfs/sadmd/sadmd.hpp
@@ -80,6 +80,10 @@ public:
     bool handle(msgs::master::file_metadata_request const&,
                 msgs::message_header const&, msgs::channel const&);
 
+    // handles a read_dir
+    bool handle(msgs::master::read_dir_request const&,
+                msgs::message_header const&, msgs::channel const&);
+
     // handles a release_lock
     bool handle(msgs::master::release_lock const&, msgs::message_header const&,
                 msgs::channel const&);

--- a/src/msgs/client/messages.cpp
+++ b/src/msgs/client/messages.cpp
@@ -24,6 +24,7 @@ auto const msg_type_lookup = msg_type_map{
     {MsgCase::kAck, msg_type::acknowledgement},
     {MsgCase::kChunkLocationRes, msg_type::chunk_location_response},
     {MsgCase::kFileMetadataRes, msg_type::file_metadata_response},
+    {MsgCase::kReadDirRes, msg_type::read_dir_response},
     {MsgCase::kReadRes, msg_type::read_response},
 };
 
@@ -111,6 +112,46 @@ extract(chunk_location_response& res, message_container const& container)
 
     // read chunk_location_response from message_container
     res.protobuf_ = container.chunk_location_res();
+    return true;
+}
+
+// ==================================================================
+//                     read_dir_response
+// ==================================================================
+read_dir_response::read_dir_response(std::vector<std::string> const& filenames)
+{
+    for (auto filename : filenames)
+    {
+    	protobuf_.add_filenames(filename);
+    }
+}
+
+// embeds a control message into a container that is
+// (typically) sent over the wire
+bool
+embed(read_dir_response const& res, message_container& container)
+{
+    // should this be in a try-catch block?
+    // container.mutable_read_dir_res() can throw if heap allocation
+    // fails
+    *container.mutable_read_dir_res() = res.protobuf_;
+    return true;
+}
+
+// extracts a control message from a container that is
+// (typically) received over the wire
+bool
+extract(read_dir_response& res, message_container const& container)
+{
+    if (msg_type_lookup.at(container.msg_case()) !=
+        read_dir_response::type)
+    {
+        // cannot extract a msg that doesn't exist
+        return false;
+    }
+
+    // read read_dir_response from message_container
+    res.protobuf_ = container.read_dir_res();
     return true;
 }
 

--- a/src/msgs/master/messages.cpp
+++ b/src/msgs/master/messages.cpp
@@ -26,6 +26,7 @@ auto const msg_type_lookup = msg_type_map{
     {MsgCase::kChunkLocationReq, msg_type::chunk_location_request},
     {MsgCase::kChunkServerHeartbeat, msg_type::chunk_server_heartbeat},
     {MsgCase::kJoinNetworkReq, msg_type::join_network_request},
+    {MsgCase::kReadDirReq, msg_type::read_dir_request},
     {MsgCase::kReleaseLock, msg_type::release_lock},
 };
 
@@ -262,6 +263,42 @@ extract(join_network_request& req, message_container const& container)
 
     // read join_network_request from message_container
     req.protobuf_ = container.join_network_req();
+    return true;
+}
+
+/* ========================================================
+ *                       read_dir_request
+ * ========================================================
+ */
+read_dir_request::read_dir_request(std::string const& dirname)
+{
+    protobuf_.set_dirname(dirname);
+}
+
+// embeds a control message into a container that is
+// (typically) sent over the wire
+bool
+embed(read_dir_request const& req, message_container& container)
+{
+    // should this be in a try-catch block?
+    // msg.mutable_read_dir_request() can throw if heap allocation fails
+    *container.mutable_read_dir_req() = req.protobuf_;
+    return true;
+}
+
+// extracts a control message from a container that is
+// (typically) received over the wire
+bool
+extract(read_dir_request& req, message_container const& container)
+{
+    if (msg_type_lookup.at(container.msg_case()) != read_dir_request::type)
+    {
+        // cannot extract a msg that doesn't exist
+        return false;
+    }
+
+    // read read_dir_request from message_container
+    req.protobuf_ = container.read_dir_req();
     return true;
 }
 

--- a/src/proto/client.proto
+++ b/src/proto/client.proto
@@ -25,6 +25,11 @@ message read_response {
 	bytes data = 2;
 }
 
+// response for a read dir request
+message read_dir_response {
+	repeated string filenames = 1;
+}
+
 // container for all control messages sent to clients
 message message_container {
 	sadfs.proto.header  header = 1;
@@ -33,5 +38,6 @@ message message_container {
 		chunk_location_response     chunk_location_res = 7;
 		file_metadata_response      file_metadata_res  = 8;
 		read_response               read_res           = 9;
+		read_dir_response	    read_dir_res       = 10;
 	}
 }

--- a/src/proto/master.proto
+++ b/src/proto/master.proto
@@ -40,6 +40,11 @@ message file_metadata_request {
 	string filename	= 1;
 }
 
+// request for list of files in a directory
+message read_dir_request {
+	string dirname = 1;
+}
+
 // notification of release of write lock
 message release_lock {
 	string filename	= 1;
@@ -56,5 +61,6 @@ message message_container {
 		create_file_request      create_file_req        = 9;
 		file_metadata_request    file_metadata_req      = 10;
 		join_network_request     join_network_req       = 11;
+		read_dir_request	 read_dir_req		= 12;
 	}
 }

--- a/src/sadfsd/sadfilesys.cpp
+++ b/src/sadfsd/sadfilesys.cpp
@@ -39,6 +39,10 @@ sadfilesys::this_()
 void
 sadfilesys::load_operations()
 {
+    operations_.create = [](char const* path, mode_t mode,
+    			    fuse_file_info* fi) -> int {
+	return this_()->create(path, mode, fi);
+    };
     operations_.getattr = [](char const* path, struct stat* stbuf) -> int {
         return this_()->getattr(path, stbuf);
     };
@@ -54,6 +58,51 @@ sadfilesys::load_operations()
                              fuse_file_info* fi) -> int {
         return this_()->readdir(path, buf, filler, off, fi);
     };
+    operations_.write = [](char const* path, const char* buf, size_t size,
+                          off_t offset, fuse_file_info* fi) -> int {
+        return this_()->write(path, buf, size, offset, fi);
+    };
+}
+
+int
+sadfilesys::create(char const* path, mode_t mode, fuse_file_info* fi)
+{
+    logger::debug("create() called at " + std::string(path));
+    auto result{0};
+
+    if (!S_ISREG(mode))
+    {
+	logger::debug("create() only support regular files"sv);
+	result = -EPROTONOSUPPORT;	// Protocol not supported
+	return result;
+    }
+    
+    auto request	= msgs::master::create_file_request{std::string(path)};
+    auto serializer	= msgs::master::serializer{};
+    auto sock		= master_service_.connect();
+    if (!sock.valid())
+    {
+    	result = -ENETUNREACH;	/// Network is unreachable
+	logger::debug("create() failed with error " +
+		      std::string(strerror(-result)));
+	return result;
+    }
+    auto ch = msgs::channel{std::move(sock)};
+    auto flush = [](auto const& ch) {
+    	ch.flush();
+	return true;
+    };
+
+    if (!(serializer.serialize(request, ch) && flush(ch)))
+    {
+    	result = -EPROTONOSUPPORT; 	// Protocol not supported
+	logger::debug("create() failed with error " +
+		      std::string(strerror(-result)));
+	return result;
+    }
+    
+    logger::debug("regular file created"sv);
+    return result;
 }
 
 int
@@ -135,7 +184,7 @@ sadfilesys::readdir(char const* path, void* buf, fuse_fill_dir_t filler,
 int
 sadfilesys::open(char const* path, fuse_file_info* fi)
 {
-    // TODO
+    logger::debug("open() called on path " + std::string(path));
     return 0;
 }
 
@@ -282,4 +331,14 @@ sadfilesys::read(char const* path, char* buf, size_t size, off_t offset,
      return result;
 }
 
+int
+sadfilesys::write(char const* path, const char* buf, size_t size, off_t offset,
+                  fuse_file_info* fi)
+{
+    logger::debug("write() called at " + std::string(path) + " to write " +
+    	          std::to_string(size) + " bytes at offset " +
+		  std::to_string(offset) + "with value " + std::string(buf));
+    
+    return strlen(buf);
+}
 } // namespace sadfs

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -55,15 +55,14 @@ namespace time
 
 using namespace std::literals;
 constexpr auto server_ttl = 1min;
-constexpr auto file_ttl   = 1min;
+constexpr auto file_ttl   = 1s;
 
-time_point
-from_now(std::chrono::minutes delta) noexcept
+auto from_now = [](auto delta) noexcept
 {
     return (std::chrono::steady_clock::now() + delta)
         .time_since_epoch()
         .count();
-}
+};
 
 time_point
 now() noexcept

--- a/src/sadmd/sadmd.cpp
+++ b/src/sadmd/sadmd.cpp
@@ -379,6 +379,28 @@ sadmd::handle(msgs::master::chunk_write_notification const& cwn,
 }
 
 bool
+sadmd::handle(msgs::master::read_dir_request const& rdr,
+	      msgs::message_header const&, msgs::channel const& ch)
+{
+    auto filenames = std::vector<std::string>{};
+    if (rdr.dirname() == "/")
+    {
+	    logger::debug("read_dir_request number of files " + 
+			  std::to_string(files_.size()));
+	    filenames.reserve(files_.size());
+	    for (auto it : files_)
+	    {
+		filenames.push_back(it.first);
+	    }
+    }
+
+    auto response = msgs::client::read_dir_response{filenames};
+    auto result = msgs::client::serializer{}.serialize(response, ch);
+    ch.flush();
+    return result;
+}
+
+bool
 sadmd::handle(msgs::master::release_lock const& rl,
               msgs::message_header const&, msgs::channel const& ch)
 {


### PR DESCRIPTION
Implemented the sadfilesys::write() function.
Yet to test on writes spanning multiple chunks and verify if any issues on macOS.
To "test"
- write I used `echo "chunk chonk" > path/to/mount/filename`
- read I used `cat path/to/mount/filename`
- append, waited 1 minute for ttl to run out, then `echo "chank chenk" >> path/to/mount/filename`